### PR TITLE
Implement student dashboard enhancements with schedule and notification previews; add KPICard and QuickActions components

### DIFF
--- a/src/components/KPICard.jsx
+++ b/src/components/KPICard.jsx
@@ -1,0 +1,1 @@
+export { default, KPICard } from './ui/KPICard'

--- a/src/pages/student/DashboardPage.jsx
+++ b/src/pages/student/DashboardPage.jsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import api from '../../services/api'
 import { useAuth } from '../../hooks/useAuth'
+import KPICard from '../../components/KPICard'
+import QuickActions from '../../components/QuickActions'
 import './DashboardPage.css'
 
 const NAV_ITEMS = [
@@ -79,6 +81,8 @@ export default function DashboardPage() {
   const studentName = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || 'Aluno'
 
   const [dashboard, setDashboard] = useState(null)
+  const [schedulePreview, setSchedulePreview] = useState([])
+  const [notificationPreview, setNotificationPreview] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
@@ -105,8 +109,15 @@ export default function DashboardPage() {
     try {
       setLoading(true)
       setError('')
-      const response = await api.get('/student/dashboard')
-      setDashboard(response.data ?? null)
+      const [dashboardResponse, scheduleResponse, notificationsResponse] = await Promise.all([
+        api.get('/student/dashboard'),
+        api.get('/student/schedule/upcoming'),
+        api.get('/notifications?preview=true'),
+      ])
+
+      setDashboard(dashboardResponse.data ?? null)
+      setSchedulePreview(scheduleResponse.data?.schedule ?? [])
+      setNotificationPreview(Array.isArray(notificationsResponse.data) ? notificationsResponse.data : [])
     } catch (requestError) {
       setError(requestError?.response?.data?.error || 'Não foi possível carregar o painel do aluno.')
     } finally {
@@ -121,7 +132,7 @@ export default function DashboardPage() {
   const unreadNotifications = dashboard?.notifications?.filter((item) => !item.read)?.length ?? 0
 
   const scheduleRows = useMemo(() => {
-    const rows = dashboard?.schedule ?? []
+    const rows = schedulePreview
     const term = searchTerm.trim().toLowerCase()
 
     if (!term) {
@@ -132,16 +143,35 @@ export default function DashboardPage() {
       const text = [row.teacher, row.studio, row.status, row.date, row.time].join(' ').toLowerCase()
       return text.includes(term)
     })
-  }, [dashboard?.schedule, searchTerm])
+  }, [schedulePreview, searchTerm])
 
   const communicationRows = useMemo(() => {
-    return (dashboard?.notifications ?? []).slice(0, 3)
-  }, [dashboard?.notifications])
+    return notificationPreview.slice(0, 3)
+  }, [notificationPreview])
 
   const quickActions = [
-    { label: 'Nova marcação', to: '/student/coaching' },
-    { label: 'Confirmar execução', to: '/student/coaching#confirmacao' },
-    { label: 'Gerir cancelamentos', to: '/student/coaching', secondary: true },
+    {
+      label: 'Abrir coaching',
+      to: '/student/coaching',
+      description: 'Consultar sessões e gerir marcações',
+    },
+    {
+      label: 'Inventário da escola',
+      to: '/student/inventory',
+      description: 'Ver artigos disponíveis para aluguer',
+      variant: 'ctaSecondary',
+    },
+    {
+      label: 'Marketplace',
+      to: '/student/marketplace',
+      description: 'Explorar e gerir compras e vendas',
+    },
+    {
+      label: 'Notificações',
+      to: '/student/notifications',
+      description: 'Ver alertas e mensagens recentes',
+      variant: 'secondary',
+    },
   ]
 
   return (
@@ -234,22 +264,9 @@ export default function DashboardPage() {
             ) : null}
 
             <div className="kpi-grid">
-              <article className="kpi">
-                <h3>Sessões agendadas</h3>
-                <strong>{dashboard?.upcomingSessions ?? 0}</strong>
-              </article>
-              <article className="kpi">
-                <h3>Validações pendentes</h3>
-                <strong>{dashboard?.pendingValidations ?? 0}</strong>
-              </article>
-              <article className="kpi">
-                <h3>Pedidos em análise</h3>
-                <strong>{dashboard?.reviewRequests ?? 0}</strong>
-              </article>
-              <article className="kpi">
-                <h3>Pagamentos externos em curso</h3>
-                <strong>{dashboard?.externalPaymentsInProgress ?? 0}</strong>
-              </article>
+              <KPICard title="Sessões agendadas" value={dashboard?.upcomingSessions ?? 0} />
+              <KPICard title="Validações pendentes" value={dashboard?.pendingValidations ?? 0} />
+              <KPICard title="Pedidos em análise" value={dashboard?.reviewRequests ?? 0} />
             </div>
 
             <div className="split">
@@ -290,13 +307,7 @@ export default function DashboardPage() {
 
               <article className="panel">
                 <h3>Ações rápidas</h3>
-                <div className="quick-actions">
-                  {quickActions.map((action) => (
-                    <Link key={action.label} className={`cta${action.secondary ? ' secondary' : ''}`} to={action.to}>
-                      {action.label}
-                    </Link>
-                  ))}
-                </div>
+                <QuickActions actions={quickActions} />
 
                 <h3>Comunicações recentes</h3>
                 {communicationRows.length === 0 ? (
@@ -305,7 +316,7 @@ export default function DashboardPage() {
                   <ul className="list">
                     {communicationRows.map((notification) => (
                       <li key={notification.id}>
-                        {notification.title}: {notification.message || 'Sem detalhe adicional.'}
+                        {notification.title || 'Notificação'}: {notification.message || 'Sem detalhe adicional.'}
                       </li>
                     ))}
                   </ul>

--- a/src/pages/student/DashboardPage.jsx
+++ b/src/pages/student/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import api from '../../services/api'
+import notificationPreviewService from '../../services/notificationPreviewService'
 import { useAuth } from '../../hooks/useAuth'
 import KPICard from '../../components/KPICard'
 import QuickActions from '../../components/QuickActions'
@@ -82,7 +83,7 @@ export default function DashboardPage() {
 
   const [dashboard, setDashboard] = useState(null)
   const [schedulePreview, setSchedulePreview] = useState([])
-  const [notificationPreview, setNotificationPreview] = useState([])
+  const [notificationPreview, setNotificationPreview] = useState({ items: [], unreadCount: 0 })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
@@ -109,15 +110,37 @@ export default function DashboardPage() {
     try {
       setLoading(true)
       setError('')
-      const [dashboardResponse, scheduleResponse, notificationsResponse] = await Promise.all([
+
+      const dashboardResult = await Promise.allSettled([
         api.get('/student/dashboard'),
         api.get('/student/schedule/upcoming'),
-        api.get('/notifications?preview=true'),
+        notificationPreviewService.getPreview({ limit: 5, includeUnreadCount: true }),
       ])
 
-      setDashboard(dashboardResponse.data ?? null)
-      setSchedulePreview(scheduleResponse.data?.schedule ?? [])
-      setNotificationPreview(Array.isArray(notificationsResponse.data) ? notificationsResponse.data : [])
+      const [dashboardPromise, schedulePromise, notificationsPromise] = dashboardResult
+
+      if (dashboardPromise.status === 'fulfilled') {
+        setDashboard(dashboardPromise.value.data ?? null)
+      } else {
+        setDashboard(null)
+      }
+
+      if (schedulePromise.status === 'fulfilled') {
+        setSchedulePreview(schedulePromise.value.data?.schedule ?? [])
+      } else {
+        setSchedulePreview([])
+      }
+
+      if (notificationsPromise.status === 'fulfilled') {
+        setNotificationPreview(notificationsPromise.value)
+      } else {
+        setNotificationPreview({ items: [], unreadCount: 0 })
+      }
+
+      const anyFailed = dashboardResult.some((result) => result.status === 'rejected')
+      if (anyFailed) {
+        setError('Alguns dados do painel não puderam ser carregados. Tente novamente.')
+      }
     } catch (requestError) {
       setError(requestError?.response?.data?.error || 'Não foi possível carregar o painel do aluno.')
     } finally {
@@ -129,7 +152,7 @@ export default function DashboardPage() {
     loadDashboard()
   }, [loadDashboard])
 
-  const unreadNotifications = dashboard?.notifications?.filter((item) => !item.read)?.length ?? 0
+  const unreadNotifications = notificationPreview?.unreadCount ?? 0
 
   const scheduleRows = useMemo(() => {
     const rows = schedulePreview
@@ -146,7 +169,7 @@ export default function DashboardPage() {
   }, [schedulePreview, searchTerm])
 
   const communicationRows = useMemo(() => {
-    return notificationPreview.slice(0, 3)
+    return notificationPreview?.items?.slice(0, 3) ?? []
   }, [notificationPreview])
 
   const quickActions = [
@@ -267,6 +290,7 @@ export default function DashboardPage() {
               <KPICard title="Sessões agendadas" value={dashboard?.upcomingSessions ?? 0} />
               <KPICard title="Validações pendentes" value={dashboard?.pendingValidations ?? 0} />
               <KPICard title="Pedidos em análise" value={dashboard?.reviewRequests ?? 0} />
+              <KPICard title="Pagamentos externos em curso" value={dashboard?.externalPaymentsInProgress ?? 0} />
             </div>
 
             <div className="split">


### PR DESCRIPTION
This pull request refactors and enhances the student dashboard page by improving data fetching, updating UI components, and streamlining the display of key information. The main changes include fetching schedule and notification previews in parallel, introducing reusable components for KPIs and quick actions, and refining how recent communications are shown.

**Data fetching and state management:**
- The dashboard now fetches the main dashboard data, upcoming schedule, and notification previews concurrently using `Promise.all`, storing results in separate state variables for better performance and separation of concerns. [[1]](diffhunk://#diff-82bcc5dae2d1557709b8b97ec86f34d3765b1dfdb5d419a347b4cddaa09ff3a5R84-R85) [[2]](diffhunk://#diff-82bcc5dae2d1557709b8b97ec86f34d3765b1dfdb5d419a347b4cddaa09ff3a5L108-R120)

**UI component improvements:**
- Replaces inline KPI markup with the reusable `KPICard` component, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-e641529f90c28445d8ec898ec6c1f6e744dc98b0e0b43a45d64b00f1527324d4R1) [[2]](diffhunk://#diff-82bcc5dae2d1557709b8b97ec86f34d3765b1dfdb5d419a347b4cddaa09ff3a5L237-R269)
- Introduces the `QuickActions` component to handle quick action links, allowing for richer descriptions and better styling.

**Logic and display refinements:**
- Updates the logic for displaying schedule and notification previews to use the newly fetched state variables, ensuring more accurate and up-to-date information. [[1]](diffhunk://#diff-82bcc5dae2d1557709b8b97ec86f34d3765b1dfdb5d419a347b4cddaa09ff3a5L124-R135) [[2]](diffhunk://#diff-82bcc5dae2d1557709b8b97ec86f34d3765b1dfdb5d419a347b4cddaa09ff3a5L135-R174)
- Enhances the quick actions array with additional actions, descriptions, and variants for improved user experience.
- Improves the rendering of recent communications by providing a fallback title for notifications without a title.