### PR TITLE
feat: implement financial dashboard and audit pages frontend (#26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1171,9 +1171,6 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1261,6 +1258,25 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1322,24 +1338,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1915,9 +1914,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1928,7 +1927,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2050,7 +2048,7 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      "license": "MIT"
+      }
     },
     "node_modules/data-urls": {
       "version": "6.0.1",
@@ -2093,15 +2091,17 @@
         }
       }
     },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -2180,27 +2180,6 @@
         "engine.io-parser": "~5.2.1",
         "ws": "~8.18.3",
         "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -2509,7 +2488,7 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
-    }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2918,14 +2897,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2934,6 +2905,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -3733,6 +3713,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3773,6 +3761,32 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
@@ -3802,40 +3816,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
-      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.13.2",
@@ -3905,6 +3885,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3920,26 +3914,6 @@
         "redux": "^5.0.0"
       }
     },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3949,6 +3923,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4157,17 +4137,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -4178,9 +4158,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4215,22 +4195,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4612,10 +4592,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
+        "recharts": "^3.8.1",
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
@@ -591,6 +592,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
+      "integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -879,6 +916,18 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -889,6 +938,69 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -908,7 +1020,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -923,6 +1035,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1156,6 +1274,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1234,8 +1361,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1253,6 +1501,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1367,6 +1621,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1574,6 +1838,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1886,6 +2156,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -1911,6 +2191,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2592,6 +2881,36 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -2629,6 +2948,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2790,6 +3160,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2867,6 +3243,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.15.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.2"
+        "react-router-dom": "^7.13.2",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -590,6 +591,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -872,6 +909,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -882,6 +931,69 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -901,7 +1013,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -916,6 +1028,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1149,6 +1267,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1227,8 +1354,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1247,6 +1495,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1339,6 +1593,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1546,6 +1810,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1858,6 +2128,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -1883,6 +2163,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2565,6 +2854,36 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -2602,6 +2921,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2735,6 +3105,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2812,6 +3188,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "axios": "^1.15.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.2"
+    "react-router-dom": "^7.13.2",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import { useAuth } from './hooks/useAuth'
 import ForgotPasswordPage from './pages/ForgotPasswordPage'
 import LoginPage from './pages/LoginPage'
 import StudioManagementPage from './pages/admin/StudioManagementPage'
+import FinancialDashboardPage from './pages/admin/FinancialDashboardPage'
+import AuditPage from './pages/admin/AuditPage'
 import DashboardPage from './pages/student/DashboardPage'
 import MarketplacePage from './pages/student/MarketplacePage'
 import MyListingsPage from './pages/student/MyListingsPage'
@@ -139,6 +141,8 @@ function App() {
       <Route element={<ProtectedRoute allowedRoles={['admin']} />}>
         <Route path="/admin/dashboard" element={<AdminDashboard />} />
         <Route path="/admin/studios" element={<StudioManagementPage />} />
+        <Route path="/admin/finance" element={<FinancialDashboardPage />} />
+        <Route path="/admin/audit" element={<AuditPage />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/src/pages/admin/AdminShell.jsx
+++ b/src/pages/admin/AdminShell.jsx
@@ -58,6 +58,20 @@ function AdminShell({ title, subtitle, activePath, children, topbarEnd }) {
     if (isMobile) setMobileOpen(false)
   }
 
+  const isNavItemActive = (href) => {
+    if (!activePath) return false
+
+    if (href === '/admin/studios') {
+      return activePath === '/admin/studios' || activePath === '/admin/studio-occupancy'
+    }
+
+    if (href === '/admin') {
+      return activePath === '/admin'
+    }
+
+    return activePath.startsWith(href)
+  }
+
   return (
     <div className={appShellClass}>
       {isMobile && mobileOpen ? (
@@ -83,7 +97,7 @@ function AdminShell({ title, subtitle, activePath, children, topbarEnd }) {
           {ADMIN_NAV_ITEMS.map((item) => (
             <Link
               key={item.href}
-              className={`nav-link${activePath === item.href ? ' active' : ''}`}
+              className={`nav-link${isNavItemActive(item.href) ? ' active' : ''}`}
               to={item.href}
               onClick={handleMobileNavClick}
             >

--- a/src/pages/admin/AdminShell.jsx
+++ b/src/pages/admin/AdminShell.jsx
@@ -34,8 +34,14 @@ function AdminShell({ title, subtitle, activePath, children, topbarEnd }) {
       if (!mq.matches) setMobileOpen(false)
     }
     update()
-    mq.addEventListener('change', update)
-    return () => mq.removeEventListener('change', update)
+
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', update)
+      return () => mq.removeEventListener('change', update)
+    }
+
+    mq.addListener(update)
+    return () => mq.removeListener(update)
   }, [])
 
   async function handleLogout() {
@@ -84,14 +90,22 @@ function AdminShell({ title, subtitle, activePath, children, topbarEnd }) {
               {item.label}
             </Link>
           ))}
-          <a
+          <button
+            type="button"
             className="nav-link"
-            href="/login"
             title={`Terminar sessão de ${displayName}`}
             onClick={handleLogout}
+            style={{
+              background: 'transparent',
+              border: 0,
+              cursor: 'pointer',
+              font: 'inherit',
+              textAlign: 'left',
+              width: '100%',
+            }}
           >
             Terminar Sessão
-          </a>
+          </button>
         </div>
       </aside>
 

--- a/src/pages/admin/AdminShell.jsx
+++ b/src/pages/admin/AdminShell.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import { ADMIN_NAV_ITEMS } from './adminNav'
+import '../admin-studios.css'
+
+function AdminShell({ title, subtitle, activePath, children, topbarEnd }) {
+  const navigate = useNavigate()
+  const { logout, user } = useAuth()
+
+  const [isMobile, setIsMobile] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+
+  const displayName = user?.fullName || user?.name || user?.email || 'Utilizador'
+
+  const sidebarHidden = isMobile || sidebarCollapsed
+  const appShellClass = ['app-shell', sidebarHidden ? 'sidebar-hidden' : ''].filter(Boolean).join(' ')
+  const sidebarClass = ['sidebar', isMobile && mobileOpen ? 'open' : ''].filter(Boolean).join(' ')
+  const toggleSymbol = isMobile ? (mobileOpen ? '✕' : '☰') : (sidebarCollapsed ? '▶' : '◀')
+  const toggleLabel = isMobile
+    ? (mobileOpen ? 'Fechar menu lateral' : 'Abrir menu lateral')
+    : (sidebarCollapsed ? 'Mostrar barra lateral' : 'Esconder barra lateral')
+
+  useEffect(() => {
+    document.body.classList.add('studio-page')
+    return () => document.body.classList.remove('studio-page')
+  }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 1024px)')
+    const update = () => {
+      setIsMobile(mq.matches)
+      if (!mq.matches) setMobileOpen(false)
+    }
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  async function handleLogout() {
+    await logout()
+    navigate('/login', { replace: true })
+  }
+
+  function handleSidebarToggle() {
+    if (isMobile) setMobileOpen((v) => !v)
+    else setSidebarCollapsed((v) => !v)
+  }
+
+  function handleMobileNavClick() {
+    if (isMobile) setMobileOpen(false)
+  }
+
+  return (
+    <div className={appShellClass}>
+      {isMobile && mobileOpen ? (
+        <button
+          type="button"
+          className="sidebar-overlay"
+          aria-label="Fechar navegação lateral"
+          onClick={() => setMobileOpen(false)}
+        />
+      ) : null}
+
+      <aside className={sidebarClass} id="sidebar">
+        <div className="brand">
+          <span className="brand-dot" />
+          <div>
+            <h1>gestArtes</h1>
+            <p>{displayName}</p>
+          </div>
+        </div>
+
+        <div className="nav-group">
+          <h2>Gestão</h2>
+          {ADMIN_NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              className={`nav-link${activePath === item.href ? ' active' : ''}`}
+              to={item.href}
+              onClick={handleMobileNavClick}
+            >
+              {item.label}
+            </Link>
+          ))}
+          <a
+            className="nav-link"
+            href="/login"
+            title={`Terminar sessão de ${displayName}`}
+            onClick={handleLogout}
+          >
+            Terminar Sessão
+          </a>
+        </div>
+      </aside>
+
+      <main className="main">
+        <header className="topbar">
+          <div className="topbar-left">
+            <div className="topbar-heading">
+              <button
+                type="button"
+                className="sidebar-toggle-btn"
+                aria-label={toggleLabel}
+                onClick={handleSidebarToggle}
+              >
+                {toggleSymbol}
+              </button>
+              <h2>{title}</h2>
+            </div>
+            {subtitle ? <p>{subtitle}</p> : null}
+          </div>
+          {topbarEnd ? <div className="topbar-right">{topbarEnd}</div> : null}
+        </header>
+
+        <div className="content">
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default AdminShell

--- a/src/pages/admin/AuditPage.jsx
+++ b/src/pages/admin/AuditPage.jsx
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { Badge } from '../../components/ui/Badge'
+import { KPICard } from '../../components/ui/KPICard'
+import { Table } from '../../components/ui/Table'
+import api from '../../services/api'
+import AdminShell from './AdminShell'
+
+const MODULES = ['finance', 'coaching', 'validations', 'marketplace', 'lostfound', 'users', 'system']
+
+const INITIAL_FILTERS = {
+  periodStart: '',
+  periodEnd: '',
+  module: '',
+}
+
+const TABLE_COLUMNS = [
+  {
+    key: 'timestamp',
+    header: 'Data / Hora',
+    render: (row) =>
+      row.timestamp
+        ? new Date(row.timestamp).toLocaleString('pt-PT', { dateStyle: 'short', timeStyle: 'short' })
+        : '—',
+  },
+  { key: 'userName', header: 'Utilizador', render: (row) => row.userName || `#${row.userId ?? '?'}` },
+  { key: 'action', header: 'Ação' },
+  { key: 'module', header: 'Módulo' },
+  {
+    key: 'result',
+    header: 'Resultado',
+    render: (row) => (
+      <Badge variant={row.result === 'success' ? 'success' : 'danger'} size="sm">
+        {row.result === 'success' ? 'Sucesso' : 'Falha'}
+      </Badge>
+    ),
+  },
+  { key: 'detail', header: 'Detalhe', render: (row) => row.detail || '—' },
+]
+
+export default function AuditPage() {
+  const location = useLocation()
+  const [filters, setFilters] = useState(INITIAL_FILTERS)
+  const [events, setEvents] = useState([])
+  const [eventTotal, setEventTotal] = useState(0)
+  const [summary, setSummary] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const buildParams = useCallback(
+    (f = filters) => {
+      const p = {}
+      if (f.periodStart) p.periodStart = f.periodStart
+      if (f.periodEnd) p.periodEnd = f.periodEnd
+      if (f.module) p.module = f.module
+      return p
+    },
+    [filters],
+  )
+
+  const loadAll = useCallback(
+    async (f) => {
+      setLoading(true)
+      setError('')
+      try {
+        const params = buildParams(f)
+        const [evRes, sumRes] = await Promise.all([
+          api.get('/admin/audit', { params: { ...params, limit: 100, offset: 0 } }),
+          api.get('/admin/audit/summary', { params }),
+        ])
+        setEvents(Array.isArray(evRes.data?.items) ? evRes.data.items : [])
+        setEventTotal(evRes.data?.total ?? 0)
+        setSummary(sumRes.data)
+      } catch {
+        setError('Não foi possível carregar os eventos de auditoria.')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [buildParams],
+  )
+
+  useEffect(() => {
+    void loadAll()
+  }, [loadAll])
+
+  function handleFilterChange(field, value) {
+    setFilters((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleFilterSubmit(e) {
+    e.preventDefault()
+    await loadAll(filters)
+  }
+
+  return (
+    <AdminShell
+      title="Auditoria"
+      subtitle="Registo de ações críticas do sistema"
+      activePath={location.pathname}
+    >
+      {error ? (
+        <p style={{ color: '#b91c1c', marginBottom: '1rem' }}>{error}</p>
+      ) : null}
+
+      {/* KPI Cards */}
+      <div
+        style={{
+          display: 'grid',
+          gap: '1rem',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <KPICard
+          title="Ações (últ. 24h)"
+          value={summary?.auditedActionsLast24h ?? 0}
+          description="Eventos auditados recentes"
+        />
+        <KPICard
+          title="Total no período"
+          value={summary?.total ?? 0}
+          description="Eventos no intervalo filtrado"
+        />
+        <KPICard
+          title="Sucessos"
+          value={summary?.byResult?.success ?? 0}
+          description="Ações bem-sucedidas"
+        />
+        <KPICard
+          title="Falhas"
+          value={summary?.byResult?.failure ?? 0}
+          description="Ações com erro"
+        />
+      </div>
+
+      {/* Filters */}
+      <form
+        onSubmit={handleFilterSubmit}
+        style={{
+          alignItems: 'flex-end',
+          background: 'var(--studio-panel, #fff)',
+          border: '1px solid var(--studio-line, #e2d9eb)',
+          borderRadius: '1rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+          padding: '1rem',
+        }}
+      >
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Data início</span>
+          <input
+            type="date"
+            value={filters.periodStart}
+            onChange={(e) => handleFilterChange('periodStart', e.target.value)}
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          />
+        </label>
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Data fim</span>
+          <input
+            type="date"
+            value={filters.periodEnd}
+            onChange={(e) => handleFilterChange('periodEnd', e.target.value)}
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          />
+        </label>
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Módulo</span>
+          <select
+            value={filters.module}
+            onChange={(e) => handleFilterChange('module', e.target.value)}
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          >
+            <option value="">Todos</option>
+            {MODULES.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            background: 'var(--studio-cta-start, #0b9d8f)',
+            border: 0,
+            borderRadius: '999px',
+            color: '#fff',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            font: 'inherit',
+            fontWeight: 600,
+            opacity: loading ? 0.7 : 1,
+            padding: '0.5rem 1.1rem',
+          }}
+        >
+          {loading ? 'A carregar…' : 'Filtrar'}
+        </button>
+      </form>
+
+      {/* Events table */}
+      <section>
+        <h3 style={{ margin: '0 0 0.75rem' }}>
+          Eventos de auditoria ({eventTotal})
+        </h3>
+        <Table
+          columns={TABLE_COLUMNS}
+          rows={events}
+          getRowKey={(row, i) => `${row.timestamp}-${i}`}
+          emptyState={loading ? 'A carregar…' : 'Sem eventos de auditoria para o período selecionado.'}
+        />
+      </section>
+    </AdminShell>
+  )
+}

--- a/src/pages/admin/AuditPage.jsx
+++ b/src/pages/admin/AuditPage.jsx
@@ -8,6 +8,29 @@ import AdminShell from './AdminShell'
 
 const MODULES = ['finance', 'coaching', 'validations', 'marketplace', 'lostfound', 'users', 'system']
 
+const MODULE_LABELS = {
+  finance: 'Finanças',
+  coaching: 'Aulas/Sessões',
+  validations: 'Validações',
+  marketplace: 'Marketplace',
+  lostfound: 'Perdidos e Achados',
+  users: 'Utilizadores',
+  system: 'Sistema',
+}
+
+const ACTION_LABELS = {
+  FINANCE_EXPORT: 'Exportação Financeira',
+  NOSHOW_PENALTY_APPLIED: 'Penalização No-Show',
+  SESSION_FINALIZED: 'Sessão Finalizada',
+  SESSION_CANCELLED: 'Sessão Cancelada',
+  VALIDATION_APPROVED: 'Validação Aprovada',
+  VALIDATION_REJECTED: 'Validação Rejeitada',
+  LOSTFOUND_CLAIMED: 'Item Reclamado',
+  LOSTFOUND_ARCHIVED: 'Item Arquivado',
+  MARKETPLACE_HIDDEN: 'Item Ocultado',
+  USER_PASSWORD_RESET: 'Reset de Password',
+}
+
 const INITIAL_FILTERS = {
   periodStart: '',
   periodEnd: '',
@@ -24,8 +47,16 @@ const TABLE_COLUMNS = [
         : '—',
   },
   { key: 'userName', header: 'Utilizador', render: (row) => row.userName || `#${row.userId ?? '?'}` },
-  { key: 'action', header: 'Ação' },
-  { key: 'module', header: 'Módulo' },
+  {
+    key: 'action',
+    header: 'Ação',
+    render: (row) => ACTION_LABELS[row.action] || row.action,
+  },
+  {
+    key: 'module',
+    header: 'Módulo',
+    render: (row) => MODULE_LABELS[row.module] || row.module,
+  },
   {
     key: 'result',
     header: 'Resultado',
@@ -68,8 +99,17 @@ export default function AuditPage() {
         setEvents(Array.isArray(evRes.data?.items) ? evRes.data.items : [])
         setEventTotal(evRes.data?.total ?? 0)
         setSummary(sumRes.data)
-      } catch {
-        if (!cancelled) setError('Não foi possível carregar os eventos de auditoria.')
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Erro ao carregar auditoria:', {
+            message: err?.message,
+            status: err?.response?.status,
+            statusText: err?.response?.statusText,
+            data: err?.response?.data,
+            url: err?.config?.url,
+          })
+          setError('Não foi possível carregar os eventos de auditoria.')
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -174,7 +214,7 @@ export default function AuditPage() {
             <option value="">Todos</option>
             {MODULES.map((m) => (
               <option key={m} value={m}>
-                {m}
+                {MODULE_LABELS[m] || m}
               </option>
             ))}
           </select>

--- a/src/pages/admin/AuditPage.jsx
+++ b/src/pages/admin/AuditPage.jsx
@@ -86,18 +86,36 @@ export default function AuditPage() {
       setLoading(true)
       setError('')
       const params = {}
+      const PAGE_SIZE = 100
       if (appliedFilters.periodStart) params.periodStart = appliedFilters.periodStart
       if (appliedFilters.periodEnd) params.periodEnd = appliedFilters.periodEnd
       if (appliedFilters.module) params.module = appliedFilters.module
 
+      async function fetchAllEvents() {
+         let offset = 0
+         let total = 0
+         const allItems = []
+         do {
+           const response = await api.get('/admin/audit', {
+             params: { ...params, limit: PAGE_SIZE, offset },
+           })
+           const items = Array.isArray(response.data?.items) ? response.data.items : []
+           total = response.data?.total ?? 0
+           allItems.push(...items)
+           offset += items.length
+           if (items.length === 0) break
+         } while (offset < total)
+         return { items: allItems, total }
+       }
+
       try {
-        const [evRes, sumRes] = await Promise.all([
-          api.get('/admin/audit', { params: { ...params, limit: 100, offset: 0 } }),
+        const [{ items, total }, sumRes] = await Promise.all([
+          fetchAllEvents(),
           api.get('/admin/audit/summary', { params }),
         ])
         if (cancelled) return
-        setEvents(Array.isArray(evRes.data?.items) ? evRes.data.items : [])
-        setEventTotal(evRes.data?.total ?? 0)
+        setEvents(items)
+        setEventTotal(total)
         setSummary(sumRes.data)
       } catch (err) {
         if (!cancelled) {

--- a/src/pages/admin/AuditPage.jsx
+++ b/src/pages/admin/AuditPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Badge } from '../../components/ui/Badge'
 import { KPICard } from '../../components/ui/KPICard'
@@ -41,56 +41,53 @@ const TABLE_COLUMNS = [
 export default function AuditPage() {
   const location = useLocation()
   const [filters, setFilters] = useState(INITIAL_FILTERS)
+  const [appliedFilters, setAppliedFilters] = useState(INITIAL_FILTERS)
   const [events, setEvents] = useState([])
   const [eventTotal, setEventTotal] = useState(0)
   const [summary, setSummary] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
-  const buildParams = useCallback(
-    (f = filters) => {
-      const p = {}
-      if (f.periodStart) p.periodStart = f.periodStart
-      if (f.periodEnd) p.periodEnd = f.periodEnd
-      if (f.module) p.module = f.module
-      return p
-    },
-    [filters],
-  )
+  useEffect(() => {
+    let cancelled = false
 
-  const loadAll = useCallback(
-    async (f) => {
+    async function run() {
       setLoading(true)
       setError('')
+      const params = {}
+      if (appliedFilters.periodStart) params.periodStart = appliedFilters.periodStart
+      if (appliedFilters.periodEnd) params.periodEnd = appliedFilters.periodEnd
+      if (appliedFilters.module) params.module = appliedFilters.module
+
       try {
-        const params = buildParams(f)
         const [evRes, sumRes] = await Promise.all([
           api.get('/admin/audit', { params: { ...params, limit: 100, offset: 0 } }),
           api.get('/admin/audit/summary', { params }),
         ])
+        if (cancelled) return
         setEvents(Array.isArray(evRes.data?.items) ? evRes.data.items : [])
         setEventTotal(evRes.data?.total ?? 0)
         setSummary(sumRes.data)
       } catch {
-        setError('Não foi possível carregar os eventos de auditoria.')
+        if (!cancelled) setError('Não foi possível carregar os eventos de auditoria.')
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
-    },
-    [buildParams],
-  )
+    }
 
-  useEffect(() => {
-    void loadAll()
-  }, [loadAll])
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [appliedFilters])
 
   function handleFilterChange(field, value) {
     setFilters((prev) => ({ ...prev, [field]: value }))
   }
 
-  async function handleFilterSubmit(e) {
+  function handleFilterSubmit(e) {
     e.preventDefault()
-    await loadAll(filters)
+    setAppliedFilters(filters)
   }
 
   return (

--- a/src/pages/admin/FinancialDashboardPage.jsx
+++ b/src/pages/admin/FinancialDashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import {
   Bar,
@@ -58,6 +58,7 @@ function fmt(n) {
 export default function FinancialDashboardPage() {
   const location = useLocation()
   const [filters, setFilters] = useState(INITIAL_FILTERS)
+  const [appliedFilters, setAppliedFilters] = useState(INITIAL_FILTERS)
   const [summary, setSummary] = useState(null)
   const [transactions, setTransactions] = useState([])
   const [transactionTotal, setTransactionTotal] = useState(0)
@@ -67,52 +68,48 @@ export default function FinancialDashboardPage() {
   const [exportLoading, setExportLoading] = useState(false)
   const [exportError, setExportError] = useState('')
 
-  const buildParams = useCallback(
-    (f = filters) => {
-      const p = {}
-      if (f.periodStart) p.periodStart = f.periodStart
-      if (f.periodEnd) p.periodEnd = f.periodEnd
-      if (f.studentNumber) p.studentNumber = f.studentNumber
-      return p
-    },
-    [filters],
-  )
+  useEffect(() => {
+    let cancelled = false
 
-  const loadAll = useCallback(
-    async (f) => {
+    async function run() {
       setLoading(true)
       setError('')
+      const params = {}
+      if (appliedFilters.periodStart) params.periodStart = appliedFilters.periodStart
+      if (appliedFilters.periodEnd) params.periodEnd = appliedFilters.periodEnd
+      if (appliedFilters.studentNumber) params.studentNumber = appliedFilters.studentNumber
+
       try {
-        const params = buildParams(f)
         const [sumRes, txRes, revRes] = await Promise.all([
           api.get('/admin/finance/summary', { params }),
           api.get('/admin/finance/transactions', { params: { ...params, limit: 50, offset: 0 } }),
           api.get('/admin/finance/revenue'),
         ])
+        if (cancelled) return
         setSummary(sumRes.data)
         setTransactions(Array.isArray(txRes.data?.items) ? txRes.data.items : [])
         setTransactionTotal(txRes.data?.total ?? 0)
         setRevenue(revRes.data)
       } catch {
-        setError('Não foi possível carregar os dados financeiros.')
+        if (!cancelled) setError('Não foi possível carregar os dados financeiros.')
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
-    },
-    [buildParams],
-  )
+    }
 
-  useEffect(() => {
-    void loadAll()
-  }, [loadAll])
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [appliedFilters])
 
   function handleFilterChange(field, value) {
     setFilters((prev) => ({ ...prev, [field]: value }))
   }
 
-  async function handleFilterSubmit(e) {
+  function handleFilterSubmit(e) {
     e.preventDefault()
-    await loadAll(filters)
+    setAppliedFilters(filters)
   }
 
   async function handleExport() {
@@ -137,7 +134,7 @@ export default function FinancialDashboardPage() {
       a.download = `financeiro_${dateTag}.csv`
       a.click()
       URL.revokeObjectURL(url)
-      await loadAll(filters)
+      setAppliedFilters(filters)
     } catch {
       setExportError('Erro ao exportar CSV.')
     } finally {

--- a/src/pages/admin/FinancialDashboardPage.jsx
+++ b/src/pages/admin/FinancialDashboardPage.jsx
@@ -22,10 +22,22 @@ const INITIAL_FILTERS = {
   studentNumber: '',
 }
 
+const ENTRY_TYPE_LABELS = {
+  session_revenue: 'Receita de Sessão',
+  no_show_fee: 'Taxa de No-Show',
+  cancellation_fee: 'Taxa de Cancelamento',
+  inventory_fee: 'Taxa de Inventário',
+  marketplace_fee: 'Taxa de Marketplace',
+}
+
 const TABLE_COLUMNS = [
   { key: 'entryId', header: 'ID' },
   { key: 'sessionId', header: 'Sessão' },
-  { key: 'entryType', header: 'Tipo' },
+  {
+    key: 'entryType',
+    header: 'Tipo',
+    render: (row) => ENTRY_TYPE_LABELS[row.entryType] || row.entryType || '—',
+  },
   {
     key: 'amount',
     header: 'Valor (€)',
@@ -144,7 +156,13 @@ export default function FinancialDashboardPage() {
       a.click()
       URL.revokeObjectURL(url)
       setAppliedFilters(filters)
-    } catch {
+    } catch (err) {
+      console.error('Erro ao exportar CSV:', {
+        message: err?.message,
+        status: err?.response?.status,
+        statusText: err?.response?.statusText,
+        data: err?.response?.data,
+      })
       setExportError('Erro ao exportar CSV.')
     } finally {
       setExportLoading(false)

--- a/src/pages/admin/FinancialDashboardPage.jsx
+++ b/src/pages/admin/FinancialDashboardPage.jsx
@@ -90,8 +90,17 @@ export default function FinancialDashboardPage() {
         setTransactions(Array.isArray(txRes.data?.items) ? txRes.data.items : [])
         setTransactionTotal(txRes.data?.total ?? 0)
         setRevenue(revRes.data)
-      } catch {
-        if (!cancelled) setError('Não foi possível carregar os dados financeiros.')
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Erro ao carregar dados financeiros:', {
+            message: err?.message,
+            status: err?.response?.status,
+            statusText: err?.response?.statusText,
+            data: err?.response?.data,
+            url: err?.config?.url,
+          })
+          setError('Não foi possível carregar os dados financeiros.')
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }

--- a/src/pages/admin/FinancialDashboardPage.jsx
+++ b/src/pages/admin/FinancialDashboardPage.jsx
@@ -75,6 +75,8 @@ export default function FinancialDashboardPage() {
   const [transactions, setTransactions] = useState([])
   const [transactionTotal, setTransactionTotal] = useState(0)
   const [revenue, setRevenue] = useState(null)
+  const [page, setPage] = useState(0)
+  const PAGE_SIZE = 50
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [exportLoading, setExportLoading] = useState(false)
@@ -94,7 +96,7 @@ export default function FinancialDashboardPage() {
       try {
         const [sumRes, txRes, revRes] = await Promise.all([
           api.get('/admin/finance/summary', { params }),
-          api.get('/admin/finance/transactions', { params: { ...params, limit: 50, offset: 0 } }),
+          api.get('/admin/finance/transactions', { params: { ...params, limit: PAGE_SIZE, offset: page * PAGE_SIZE } }),
           api.get('/admin/finance/revenue'),
         ])
         if (cancelled) return
@@ -122,7 +124,7 @@ export default function FinancialDashboardPage() {
     return () => {
       cancelled = true
     }
-  }, [appliedFilters])
+  }, [appliedFilters, page])
 
   function handleFilterChange(field, value) {
     setFilters((prev) => ({ ...prev, [field]: value }))
@@ -130,6 +132,7 @@ export default function FinancialDashboardPage() {
 
   function handleFilterSubmit(e) {
     e.preventDefault()
+    setPage(0)
     setAppliedFilters(filters)
   }
 
@@ -138,9 +141,9 @@ export default function FinancialDashboardPage() {
     setExportError('')
     try {
       const body = {}
-      if (filters.periodStart) body.periodStart = filters.periodStart
-      if (filters.periodEnd) body.periodEnd = filters.periodEnd
-      if (filters.studentNumber) body.studentNumber = filters.studentNumber
+      if (appliedFilters.periodStart) body.periodStart = appliedFilters.periodStart
+      if (appliedFilters.periodEnd) body.periodEnd = appliedFilters.periodEnd
+      if (appliedFilters.studentNumber) body.studentNumber = appliedFilters.studentNumber
 
       if (!body.periodStart || !body.periodEnd) {
         setExportError('Seleciona um período (data início e data fim) antes de exportar.')
@@ -155,7 +158,6 @@ export default function FinancialDashboardPage() {
       a.download = `financeiro_${dateTag}.csv`
       a.click()
       URL.revokeObjectURL(url)
-      setAppliedFilters(filters)
     } catch (err) {
       console.error('Erro ao exportar CSV:', {
         message: err?.message,
@@ -298,15 +300,56 @@ export default function FinancialDashboardPage() {
 
       {/* Transactions table */}
       <section style={{ marginBottom: '2rem' }}>
-        <h3 style={{ margin: '0 0 0.75rem' }}>
-          Movimentações ({transactionTotal})
-        </h3>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+          <h3 style={{ margin: 0 }}>
+            Movimentações ({transactionTotal})
+          </h3>
+          <span style={{ fontSize: '0.85rem', color: 'var(--text-muted, #666)' }}>
+            Mostrando {transactions.length > 0 ? page * PAGE_SIZE + 1 : 0} - {page * PAGE_SIZE + transactions.length} de {transactionTotal}
+          </span>
+        </div>
         <Table
           columns={TABLE_COLUMNS}
           rows={transactions}
           getRowKey={(row) => row.entryId}
           emptyState={loading ? 'A carregar…' : 'Sem movimentações para o período selecionado.'}
         />
+
+        {transactionTotal > PAGE_SIZE && (
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', justifyContent: 'center' }}>
+            <button
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={page === 0 || loading}
+              style={{
+                background: 'var(--studio-panel, #fff)',
+                border: '1px solid var(--studio-line, #ccc)',
+                borderRadius: '0.5rem',
+                padding: '0.4rem 0.8rem',
+                cursor: (page === 0 || loading) ? 'not-allowed' : 'pointer',
+                opacity: (page === 0 || loading) ? 0.5 : 1
+              }}
+            >
+              Anterior
+            </button>
+            <span style={{ display: 'flex', alignItems: 'center', padding: '0 0.5rem' }}>
+              Página {page + 1} de {Math.ceil(transactionTotal / PAGE_SIZE)}
+            </span>
+            <button
+              onClick={() => setPage(p => p + 1)}
+              disabled={(page + 1) * PAGE_SIZE >= transactionTotal || loading}
+              style={{
+                background: 'var(--studio-panel, #fff)',
+                border: '1px solid var(--studio-line, #ccc)',
+                borderRadius: '0.5rem',
+                padding: '0.4rem 0.8rem',
+                cursor: ((page + 1) * PAGE_SIZE >= transactionTotal || loading) ? 'not-allowed' : 'pointer',
+                opacity: ((page + 1) * PAGE_SIZE >= transactionTotal || loading) ? 0.5 : 1
+              }}
+            >
+              Próxima
+            </button>
+          </div>
+        )}
       </section>
 
       {/* Revenue chart */}

--- a/src/pages/admin/FinancialDashboardPage.jsx
+++ b/src/pages/admin/FinancialDashboardPage.jsx
@@ -1,0 +1,316 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { Badge } from '../../components/ui/Badge'
+import { KPICard } from '../../components/ui/KPICard'
+import { Table } from '../../components/ui/Table'
+import api from '../../services/api'
+import AdminShell from './AdminShell'
+
+const INITIAL_FILTERS = {
+  periodStart: '',
+  periodEnd: '',
+  studentNumber: '',
+}
+
+const TABLE_COLUMNS = [
+  { key: 'entryId', header: 'ID' },
+  { key: 'sessionId', header: 'Sessão' },
+  { key: 'entryType', header: 'Tipo' },
+  {
+    key: 'amount',
+    header: 'Valor (€)',
+    render: (row) => `${Number(row.amount).toFixed(2)} €`,
+  },
+  {
+    key: 'createdAt',
+    header: 'Data',
+    render: (row) =>
+      row.createdAt
+        ? new Date(row.createdAt).toLocaleDateString('pt-PT')
+        : '—',
+  },
+  { key: 'studentName', header: 'Aluno', render: (row) => row.studentName || '—' },
+  {
+    key: 'isExported',
+    header: 'Exportado',
+    render: (row) => (
+      <Badge variant={row.isExported ? 'success' : 'neutral'} size="sm">
+        {row.isExported ? 'Sim' : 'Não'}
+      </Badge>
+    ),
+  },
+]
+
+function fmt(n) {
+  return typeof n === 'number' ? n.toFixed(2) : '0.00'
+}
+
+export default function FinancialDashboardPage() {
+  const location = useLocation()
+  const [filters, setFilters] = useState(INITIAL_FILTERS)
+  const [summary, setSummary] = useState(null)
+  const [transactions, setTransactions] = useState([])
+  const [transactionTotal, setTransactionTotal] = useState(0)
+  const [revenue, setRevenue] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [exportLoading, setExportLoading] = useState(false)
+  const [exportError, setExportError] = useState('')
+
+  const buildParams = useCallback(
+    (f = filters) => {
+      const p = {}
+      if (f.periodStart) p.periodStart = f.periodStart
+      if (f.periodEnd) p.periodEnd = f.periodEnd
+      if (f.studentNumber) p.studentNumber = f.studentNumber
+      return p
+    },
+    [filters],
+  )
+
+  const loadAll = useCallback(
+    async (f) => {
+      setLoading(true)
+      setError('')
+      try {
+        const params = buildParams(f)
+        const [sumRes, txRes, revRes] = await Promise.all([
+          api.get('/admin/finance/summary', { params }),
+          api.get('/admin/finance/transactions', { params: { ...params, limit: 50, offset: 0 } }),
+          api.get('/admin/finance/revenue'),
+        ])
+        setSummary(sumRes.data)
+        setTransactions(Array.isArray(txRes.data?.items) ? txRes.data.items : [])
+        setTransactionTotal(txRes.data?.total ?? 0)
+        setRevenue(revRes.data)
+      } catch {
+        setError('Não foi possível carregar os dados financeiros.')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [buildParams],
+  )
+
+  useEffect(() => {
+    void loadAll()
+  }, [loadAll])
+
+  function handleFilterChange(field, value) {
+    setFilters((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleFilterSubmit(e) {
+    e.preventDefault()
+    await loadAll(filters)
+  }
+
+  async function handleExport() {
+    setExportLoading(true)
+    setExportError('')
+    try {
+      const body = {}
+      if (filters.periodStart) body.periodStart = filters.periodStart
+      if (filters.periodEnd) body.periodEnd = filters.periodEnd
+      if (filters.studentNumber) body.studentNumber = filters.studentNumber
+
+      if (!body.periodStart || !body.periodEnd) {
+        setExportError('Seleciona um período (data início e data fim) antes de exportar.')
+        return
+      }
+
+      const res = await api.post('/admin/finance/export', body, { responseType: 'blob' })
+      const url = URL.createObjectURL(res.data)
+      const a = document.createElement('a')
+      const dateTag = new Date().toISOString().slice(0, 10)
+      a.href = url
+      a.download = `financeiro_${dateTag}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+      await loadAll(filters)
+    } catch {
+      setExportError('Erro ao exportar CSV.')
+    } finally {
+      setExportLoading(false)
+    }
+  }
+
+  const chartData = revenue?.months ?? []
+
+  return (
+    <AdminShell
+      title="Finanças"
+      subtitle="Movimentações financeiras, resumo e exportação"
+      activePath={location.pathname}
+    >
+      {error ? (
+        <p style={{ color: '#b91c1c', marginBottom: '1rem' }}>{error}</p>
+      ) : null}
+
+      {/* KPI Cards */}
+      <div
+        style={{
+          display: 'grid',
+          gap: '1rem',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          marginBottom: '1.5rem',
+        }}
+      >
+        <KPICard
+          title="Receita Total"
+          value={`${fmt(summary?.totalRevenue ?? 0)} €`}
+          description="Sessões de coaching"
+        />
+        <KPICard
+          title="Total Penalizações"
+          value={`${fmt(summary?.totalPenalties ?? 0)} €`}
+          description="No-shows e cancelamentos"
+        />
+        <KPICard
+          title="Entradas"
+          value={summary?.totalEntries ?? 0}
+          description="Total de registos"
+        />
+        <KPICard
+          title="Exportados"
+          value={summary?.exportedCount ?? 0}
+          description={`Por exportar: ${summary?.unexportedCount ?? 0}`}
+        />
+      </div>
+
+      {/* Filters */}
+      <form
+        onSubmit={handleFilterSubmit}
+        style={{
+          alignItems: 'flex-end',
+          background: 'var(--studio-panel, #fff)',
+          border: '1px solid var(--studio-line, #e2d9eb)',
+          borderRadius: '1rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+          padding: '1rem',
+        }}
+      >
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Data início</span>
+          <input
+            type="date"
+            value={filters.periodStart}
+            onChange={(e) => handleFilterChange('periodStart', e.target.value)}
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          />
+        </label>
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Data fim</span>
+          <input
+            type="date"
+            value={filters.periodEnd}
+            onChange={(e) => handleFilterChange('periodEnd', e.target.value)}
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          />
+        </label>
+        <label style={{ display: 'grid', gap: '0.3rem' }}>
+          <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>Nº aluno (opcional)</span>
+          <input
+            type="text"
+            value={filters.studentNumber}
+            onChange={(e) => handleFilterChange('studentNumber', e.target.value)}
+            placeholder="ST-0001"
+            style={{ borderRadius: '0.5rem', border: '1px solid var(--studio-line, #ccc)', padding: '0.45rem 0.65rem' }}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            background: 'var(--studio-cta-start, #0b9d8f)',
+            border: 0,
+            borderRadius: '999px',
+            color: '#fff',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            font: 'inherit',
+            fontWeight: 600,
+            opacity: loading ? 0.7 : 1,
+            padding: '0.5rem 1.1rem',
+          }}
+        >
+          {loading ? 'A carregar…' : 'Filtrar'}
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={exportLoading}
+          style={{
+            background: 'var(--studio-cta-secondary-start, #55436d)',
+            border: 0,
+            borderRadius: '999px',
+            color: '#fff',
+            cursor: exportLoading ? 'not-allowed' : 'pointer',
+            font: 'inherit',
+            fontWeight: 600,
+            opacity: exportLoading ? 0.7 : 1,
+            padding: '0.5rem 1.1rem',
+          }}
+        >
+          {exportLoading ? 'A exportar…' : 'Exportar CSV'}
+        </button>
+      </form>
+
+      {exportError ? (
+        <p style={{ color: '#b91c1c', marginBottom: '1rem' }}>{exportError}</p>
+      ) : null}
+
+      {/* Transactions table */}
+      <section style={{ marginBottom: '2rem' }}>
+        <h3 style={{ margin: '0 0 0.75rem' }}>
+          Movimentações ({transactionTotal})
+        </h3>
+        <Table
+          columns={TABLE_COLUMNS}
+          rows={transactions}
+          getRowKey={(row) => row.entryId}
+          emptyState={loading ? 'A carregar…' : 'Sem movimentações para o período selecionado.'}
+        />
+      </section>
+
+      {/* Revenue chart */}
+      <section>
+        <h3 style={{ margin: '0 0 0.75rem' }}>
+          Receita mensal — {revenue?.year ?? new Date().getFullYear()}
+        </h3>
+        <div
+          style={{
+            background: 'var(--studio-panel, #fff)',
+            border: '1px solid var(--studio-line, #e2d9eb)',
+            borderRadius: '1rem',
+            padding: '1.25rem',
+          }}
+        >
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+              <YAxis tick={{ fontSize: 12 }} unit=" €" />
+              <Tooltip formatter={(val) => `${Number(val).toFixed(2)} €`} />
+              <Legend />
+              <Bar dataKey="revenue" name="Sessões (€)" fill="#0b9d8f" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="penalties" name="Penalizações (€)" fill="#f08a5d" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </AdminShell>
+  )
+}

--- a/src/pages/admin/adminNav.js
+++ b/src/pages/admin/adminNav.js
@@ -1,0 +1,11 @@
+export const ADMIN_NAV_ITEMS = [
+  { href: '/admin/dashboard', label: 'Painel' },
+  { href: '/admin/validations', label: 'Validações' },
+  { href: '/admin/studios', label: 'Estúdios' },
+  { href: '/admin/users', label: 'Utilizadores' },
+  { href: '/admin/lostfound', label: 'Perdidos e Achados' },
+  { href: '/admin/inventory', label: 'Inventário da Escola' },
+  { href: '/admin/marketplace', label: 'Marketplace' },
+  { href: '/admin/finance', label: 'Finanças' },
+  { href: '/admin/audit', label: 'Auditoria' },
+]

--- a/src/pages/admin/adminNav.js
+++ b/src/pages/admin/adminNav.js
@@ -1,11 +1,7 @@
 export const ADMIN_NAV_ITEMS = [
   { href: '/admin/dashboard', label: 'Painel' },
-  { href: '/admin/validations', label: 'Validações' },
   { href: '/admin/studios', label: 'Estúdios' },
   { href: '/admin/users', label: 'Utilizadores' },
-  { href: '/admin/lostfound', label: 'Perdidos e Achados' },
-  { href: '/admin/inventory', label: 'Inventário da Escola' },
-  { href: '/admin/marketplace', label: 'Marketplace' },
   { href: '/admin/finance', label: 'Finanças' },
   { href: '/admin/audit', label: 'Auditoria' },
 ]

--- a/src/pages/admin/adminNav.js
+++ b/src/pages/admin/adminNav.js
@@ -2,6 +2,10 @@ export const ADMIN_NAV_ITEMS = [
   { href: '/admin/dashboard', label: 'Painel' },
   { href: '/admin/studios', label: 'Estúdios' },
   { href: '/admin/users', label: 'Utilizadores' },
+  { href: '/admin/validations', label: 'Validações' },
+  { href: '/admin/lost-and-found', label: 'Perdidos e Achados' },
+  { href: '/admin/inventory', label: 'Inventário' },
+  { href: '/admin/marketplace', label: 'Marketplace' },
   { href: '/admin/finance', label: 'Finanças' },
   { href: '/admin/audit', label: 'Auditoria' },
 ]


### PR DESCRIPTION
Add admin financial dashboard (KPI cards, date/student filters, ledger table, monthly bar chart via recharts, CSV export) and audit page (KPI cards, event log table with module/period filters). Shared AdminShell component avoids duplicating sidebar+topbar logic across admin pages.

New routes (role: admin):
  /admin/finance  →  FinancialDashboardPage
  /admin/audit    →  AuditPage