### PR TITLE
refactor(web): streamline studio management service by removing redundant error handling and enhancing list normalization

### DIFF
--- a/src/services/studioManagementService.js
+++ b/src/services/studioManagementService.js
@@ -7,6 +7,17 @@ const LOCAL_OPTIONS_KEY = 'gestartes:studios:local-options'
 function normalizeList(value) {
   if (Array.isArray(value)) {
     return value
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return entry
+        }
+
+        if (entry && typeof entry === 'object') {
+          return entry.modalityName || entry.name || entry.label || entry.value || ''
+        }
+
+        return String(entry || '')
+      })
       .map((entry) => String(entry || '').trim())
       .filter(Boolean)
   }
@@ -28,7 +39,7 @@ function formatOptionValues(values) {
         return entry
       }
 
-      return entry?.name || entry?.label || entry?.value || ''
+      return entry?.name || entry?.label || entry?.value || entry?.modalityName || ''
     }),
   )
 }
@@ -208,13 +219,8 @@ function deriveOptionsFromStudios(studios) {
 
 const studioManagementService = {
   async listStudios() {
-    try {
-      const response = await api.get('/admin/studios')
-      const studios = parseStudiosPayload(response.data)
-      return studios
-    } catch {
-      return loadLocalStudios()
-    }
+    const response = await api.get('/admin/studios')
+    return parseStudiosPayload(response.data)
   },
 
   async listStudioOptions() {
@@ -247,61 +253,16 @@ const studioManagementService = {
 
   async createStudio(payload) {
     const normalized = normalizeStudioPayload(payload)
-
-    try {
-      await api.post('/admin/studios', normalized)
-      return
-    } catch {
-      const studios = loadLocalStudios()
-      const nextStudio = formatStudio({
-        id: createLocalStudioId(studios),
-        name: normalized.studioName,
-        capacity: normalized.capacity,
-        formats: normalized.formats,
-        modalities: normalized.modalities,
-      })
-
-      saveLocalStudios([nextStudio, ...studios])
-    }
+    await api.post('/admin/studios', normalized)
   },
 
   async updateStudio(studioId, payload) {
     const normalized = normalizeStudioPayload(payload)
-
-    try {
-      await api.patch(`/admin/studios/${studioId}`, normalized)
-      return
-    } catch {
-      const studios = loadLocalStudios()
-      const targetId = String(studioId)
-
-      const updated = studios.map((studio) => {
-        if (String(studio.id) !== targetId) {
-          return studio
-        }
-
-        return formatStudio({
-          id: studio.id,
-          name: normalized.studioName,
-          capacity: normalized.capacity,
-          formats: normalized.formats,
-          modalities: normalized.modalities,
-        })
-      })
-
-      saveLocalStudios(updated)
-    }
+    await api.patch(`/admin/studios/${studioId}`, normalized)
   },
 
   async deleteStudio(studioId) {
-    try {
-      await api.delete(`/admin/studios/${studioId}`)
-      return
-    } catch {
-      const targetId = String(studioId)
-      const studios = loadLocalStudios()
-      saveLocalStudios(studios.filter((studio) => String(studio.id) !== targetId))
-    }
+    await api.delete(`/admin/studios/${studioId}`)
   },
 
   async createStudioOption({ type, name }) {
@@ -312,20 +273,12 @@ const studioManagementService = {
       throw new Error('Nome inválido.')
     }
 
-    try {
-      await api.post('/admin/studios/options', {
-        type: normalizedType,
-        name: normalizedName,
-      })
+    await api.post('/admin/studios/options', {
+      type: normalizedType,
+      name: normalizedName,
+    })
 
-      return normalizedName
-    } catch {
-      const options = loadLocalOptions()
-      options[normalizedType] = uniqueNames([...(options[normalizedType] || []), normalizedName])
-      saveLocalOptions(options)
-
-      return normalizedName
-    }
+    return normalizedName
   },
 }
 


### PR DESCRIPTION
This pull request refactors the `studioManagementService` by removing local fallback logic and improving how option values are extracted and normalized. The service now relies solely on API requests for studio and option management, and the normalization functions are enhanced to better handle different object shapes.

Key changes include:

**Refactoring of error handling and local fallback logic:**

* Removed all local fallback logic from `studioManagementService` methods (`listStudios`, `createStudio`, `updateStudio`, `deleteStudio`, and `createStudioOption`). These methods now only perform API requests and no longer attempt to read from or write to local storage if the API call fails. [[1]](diffhunk://#diff-f77a4e266e68396d10fb11866f930179bad34883f1942b06ecdf4f70779209c5L211-R223) [[2]](diffhunk://#diff-f77a4e266e68396d10fb11866f930179bad34883f1942b06ecdf4f70779209c5L250-L304) [[3]](diffhunk://#diff-f77a4e266e68396d10fb11866f930179bad34883f1942b06ecdf4f70779209c5L315-L328)

**Improvements to option value normalization:**

* Updated `normalizeList` to extract option values from additional fields (`modalityName`, `name`, `label`, `value`) and handle objects more robustly.
* Modified `formatOptionValues` to include `modalityName` as a possible source for option value extraction.