### PR TITLE
feat(admin-marketplace): add moderation panel UI and API client

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ForgotPasswordPage from './pages/ForgotPasswordPage'
 import LoginPage from './pages/LoginPage'
 import StudioManagementPage from './pages/admin/StudioManagementPage'
 import AdminUsersPage from './pages/admin/AdminUsersPage'
+import MarketplaceModerationPage from './pages/admin/MarketplaceModerationPage'
 import DashboardPage from './pages/student/DashboardPage'
 import AdmissionRequestsPage from './pages/teacher/AdmissionRequestsPage'
 import InventoryPage from './pages/student/InventoryPage'
@@ -154,6 +155,7 @@ function App() {
         <Route path="/admin/dashboard" element={<AdminDashboard />} />
         <Route path="/admin/studios" element={<StudioManagementPage />} />
         <Route path="/admin/users" element={<AdminUsersPage />} />
+        <Route path="/admin/marketplace" element={<MarketplaceModerationPage />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/src/components/ListingCard.jsx
+++ b/src/components/ListingCard.jsx
@@ -1,3 +1,5 @@
+import { resolveMarketplacePhotoUrl } from '../utils/marketplace-photo-url'
+
 function formatMoney(value) {
   const numeric = Number(value)
 
@@ -36,7 +38,7 @@ export default function ListingCard({
   onDelete,
   showOwnerActions = false,
 }) {
-  const photoUrl = listing?.photoUrl || null
+  const photoUrl = resolveMarketplacePhotoUrl(listing?.photoUrl)
 
   return (
     <article className="market-listing-card">

--- a/src/components/ListingDetailModal.jsx
+++ b/src/components/ListingDetailModal.jsx
@@ -1,3 +1,4 @@
+import { resolveMarketplacePhotoUrl } from '../utils/marketplace-photo-url'
 import Modal from './ui/Modal'
 
 function normalizePhone(phoneNumber) {
@@ -10,6 +11,7 @@ export default function ListingDetailModal({ open, listing, onClose }) {
   const whatsappDigits = normalizePhone(seller?.phoneNumber)
   const whatsappHref = whatsappDigits ? `https://wa.me/${whatsappDigits}` : null
   const mailHref = seller?.email ? `mailto:${seller.email}` : null
+  const photoUrl = resolveMarketplacePhotoUrl(listing?.photoUrl)
 
   return (
     <Modal
@@ -21,8 +23,8 @@ export default function ListingDetailModal({ open, listing, onClose }) {
     >
       <div className="market-detail-grid">
         <div>
-          {listing?.photoUrl ? (
-            <img className="market-detail-image" src={listing.photoUrl} alt={listing.title || 'Anuncio'} />
+          {photoUrl ? (
+            <img className="market-detail-image" src={photoUrl} alt={listing.title || 'Anuncio'} />
           ) : (
             <div className="market-detail-image market-detail-image-empty">Sem imagem</div>
           )}

--- a/src/components/ListingForm.jsx
+++ b/src/components/ListingForm.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { resolveMarketplacePhotoUrl } from '../utils/marketplace-photo-url'
 
 const DEFAULT_VALUES = {
   title: '',
@@ -31,7 +32,7 @@ export default function ListingForm({
       categoryId: initialValues?.categoryId ?? initialValues?.category?.categoryId ?? '',
       conditionId: initialValues?.conditionId ?? initialValues?.condition?.conditionId ?? '',
     })
-    setPreviewUrl(initialValues?.photoUrl || '')
+    setPreviewUrl(resolveMarketplacePhotoUrl(initialValues?.photoUrl))
     setSelectedFile(null)
     setError('')
   }, [initialValues])

--- a/src/pages/admin-studios.css
+++ b/src/pages/admin-studios.css
@@ -517,6 +517,160 @@ body.studio-page #root {
   color: var(--studio-error-ink);
 }
 
+.app-shell .marketplace-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.app-shell .moderation-action-btn {
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 8px 12px;
+  transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
+}
+
+.app-shell .moderation-action-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.app-shell .moderation-action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.app-shell .moderation-action-btn.neutral {
+  border: 1px solid var(--studio-ghost-line);
+  background: var(--studio-field-bg);
+  color: var(--studio-ghost-ink);
+}
+
+.app-shell .moderation-action-btn.approve {
+  border: 1px solid color-mix(in srgb, var(--studio-cta-start) 48%, #ffffff 52%);
+  background: color-mix(in srgb, var(--studio-cta-start) 15%, #ffffff 85%);
+  color: #0d6b63;
+}
+
+.app-shell .moderation-action-btn.reject {
+  border: 1px solid #f2bf9b;
+  background: #fff4ea;
+  color: #8b4a22;
+}
+
+.app-shell .moderation-action-btn.delete {
+  border: 1px solid var(--studio-danger-line);
+  background: var(--studio-danger-bg);
+  color: var(--studio-danger-ink);
+}
+
+.app-shell .marketplace-modal-footer-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.app-shell .marketplace-preview-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+}
+
+.app-shell .marketplace-modal-main-column,
+.app-shell .marketplace-modal-side-column {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.app-shell .marketplace-modal-image {
+  width: 100%;
+  border-radius: 1rem;
+  border: 1px solid var(--studio-line);
+  object-fit: cover;
+  aspect-ratio: 4 / 3;
+}
+
+.app-shell .marketplace-modal-image-empty {
+  align-items: center;
+  aspect-ratio: 4 / 3;
+  background: var(--studio-soft-bg);
+  border: 1px dashed var(--studio-soft-line);
+  border-radius: 1rem;
+  color: var(--studio-muted);
+  display: grid;
+  justify-items: center;
+}
+
+.app-shell .marketplace-modal-meta-block {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.app-shell .marketplace-modal-meta-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.app-shell .marketplace-modal-price {
+  color: var(--studio-muted);
+  font-weight: 600;
+}
+
+.app-shell .marketplace-modal-description {
+  margin: 0;
+  color: var(--studio-muted);
+}
+
+.app-shell .marketplace-modal-registered-reason {
+  margin-top: 0.25rem;
+}
+
+.app-shell .marketplace-modal-line-first {
+  margin: 0.35rem 0 0;
+}
+
+.app-shell .marketplace-modal-line-regular {
+  margin: 0.1rem 0 0;
+}
+
+.app-shell .marketplace-modal-line-subtle {
+  margin: 0.1rem 0 0;
+  color: var(--studio-muted);
+}
+
+.app-shell .marketplace-rejection-panel {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.app-shell .marketplace-rejection-title {
+  color: var(--studio-ink);
+  font-weight: 600;
+}
+
+.app-shell .marketplace-rejection-panel textarea {
+  background: var(--studio-field-bg);
+  border: 1px solid var(--studio-field-line);
+  border-radius: 0.85rem;
+  color: var(--studio-ink);
+  font: inherit;
+  padding: 0.8rem 0.9rem;
+  resize: vertical;
+  width: 100%;
+}
+
+.app-shell .marketplace-rejection-help {
+  color: var(--studio-muted);
+  font-size: 0.85rem;
+}
+
+.app-shell .marketplace-rejection-hint {
+  margin: 0;
+}
+
 .app-shell .sidebar-toggle-btn {
   width: 34px;
   height: 34px;
@@ -576,6 +730,10 @@ body.studio-page #root {
   }
 
   .app-shell .form-grid.two {
+    grid-template-columns: 1fr;
+  }
+
+  .app-shell .marketplace-preview-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/pages/admin/MarketplaceModerationPage.jsx
+++ b/src/pages/admin/MarketplaceModerationPage.jsx
@@ -6,7 +6,9 @@ import Badge from '../../components/ui/Badge'
 import Input from '../../components/ui/Input'
 import Modal from '../../components/ui/Modal'
 import Table from '../../components/ui/Table'
+import { resolveMarketplacePhotoUrl } from '../../utils/marketplace-photo-url'
 import '../admin-studios.css'
+import './marketplace-moderation.css'
 
 const navigationItems = [
   { href: '/admin/dashboard', label: 'Painel' },
@@ -139,6 +141,8 @@ export default function MarketplaceModerationPage() {
   const [selectedListing, setSelectedListing] = useState(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
+  const [isRejectMode, setIsRejectMode] = useState(false)
+  const [modalImageFailed, setModalImageFailed] = useState(false)
   const [submittingAction, setSubmittingAction] = useState('')
   const [filters, setFilters] = useState({
     search: '',
@@ -214,10 +218,10 @@ export default function MarketplaceModerationPage() {
   }, [])
 
   useEffect(() => {
-    if (isModalOpen && selectedListing) {
+    if (isModalOpen && selectedListing && isRejectMode) {
       reasonRef.current?.focus?.()
     }
-  }, [isModalOpen, selectedListing])
+  }, [isModalOpen, isRejectMode, selectedListing])
 
   const filteredListings = useMemo(() => {
     const search = filters.search.trim().toLowerCase()
@@ -271,6 +275,8 @@ export default function MarketplaceModerationPage() {
   }, [listings])
 
   const selectedStatusTone = getStatusTone(selectedListing?.status?.statusName)
+  const selectedListingPhotoUrl = useMemo(() => resolveMarketplacePhotoUrl(selectedListing?.photoUrl), [selectedListing?.photoUrl])
+  const selectedIsApproved = selectedStatusTone === 'success'
 
   const updateFilter = (field, value) => {
     setFilters((current) => ({
@@ -282,6 +288,8 @@ export default function MarketplaceModerationPage() {
   const openListing = (listing, shouldSelectReject = false) => {
     setSelectedListing(listing)
     setRejectionReason(listing?.rejectionReason || '')
+    setIsRejectMode(Boolean(shouldSelectReject))
+    setModalImageFailed(false)
     setIsModalOpen(true)
 
     if (shouldSelectReject) {
@@ -295,6 +303,8 @@ export default function MarketplaceModerationPage() {
     setIsModalOpen(false)
     setSelectedListing(null)
     setRejectionReason('')
+    setIsRejectMode(false)
+    setModalImageFailed(false)
   }
 
   async function handleModeration(action, listing, payloadReason = '') {
@@ -580,13 +590,13 @@ export default function MarketplaceModerationPage() {
                   getRowKey={(listing) => listing.listingId}
                   emptyState="Não existem anúncios com os filtros atuais."
                   renderRowActions={(listing) => (
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
-                      <button type="button" className="ghost-btn" onClick={() => openListing(listing)}>
+                    <div className="marketplace-row-actions">
+                      <button type="button" className="moderation-action-btn neutral" onClick={() => openListing(listing)}>
                         Ver
                       </button>
                       <button
                         type="button"
-                        className="ghost-btn"
+                        className="moderation-action-btn approve"
                         disabled={submittingAction === 'approve' || getStatusTone(listing.status?.statusName) === 'success'}
                         onClick={() => void handleModeration('approve', listing)}
                       >
@@ -594,7 +604,7 @@ export default function MarketplaceModerationPage() {
                       </button>
                       <button
                         type="button"
-                        className="ghost-btn"
+                        className="moderation-action-btn reject"
                         disabled={submittingAction === 'reject'}
                         onClick={() => openListing(listing, true)}
                       >
@@ -602,7 +612,7 @@ export default function MarketplaceModerationPage() {
                       </button>
                       <button
                         type="button"
-                        className="danger-btn"
+                        className="moderation-action-btn delete"
                         disabled={submittingAction === 'delete'}
                         onClick={() => void handleModeration('delete', listing)}
                       >
@@ -621,29 +631,40 @@ export default function MarketplaceModerationPage() {
         open={isModalOpen}
         onClose={closeModal}
         title={selectedListing?.title || 'Detalhe do anúncio'}
-        description="Revisa o anúncio, consulta a informação enviada e decide o estado de publicação."
+        description="Revê o anúncio, consulta a informação enviada e decide o estado de publicação."
         size="xl"
         footer={
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'flex-end' }}>
+          <div className="marketplace-modal-footer-actions">
             <button
               type="button"
-              className="ghost-btn"
-              disabled={submittingAction === 'approve'}
+              className="moderation-action-btn approve"
+              disabled={submittingAction === 'approve' || selectedIsApproved}
               onClick={() => void handleModeration('approve', selectedListing)}
             >
-              Aprovar
+              {selectedIsApproved ? 'Já aprovado' : 'Aprovar anúncio'}
             </button>
+            {isRejectMode ? (
+              <button
+                type="button"
+                className="moderation-action-btn reject"
+                disabled={submittingAction === 'reject'}
+                onClick={() => void handleModeration('reject', selectedListing, rejectionReason)}
+              >
+                Confirmar rejeição
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="moderation-action-btn reject"
+                disabled={submittingAction === 'reject'}
+                onClick={() => setIsRejectMode(true)}
+              >
+                Rejeitar anúncio
+              </button>
+            )}
             <button
               type="button"
-              className="ghost-btn"
-              disabled={submittingAction === 'reject'}
-              onClick={() => void handleModeration('reject', selectedListing, rejectionReason)}
-            >
-              Rejeitar
-            </button>
-            <button
-              type="button"
-              className="danger-btn"
+              className="moderation-action-btn delete"
               disabled={submittingAction === 'delete'}
               onClick={() => void handleModeration('delete', selectedListing)}
             >
@@ -652,100 +673,80 @@ export default function MarketplaceModerationPage() {
           </div>
         }
       >
-        <div className="marketplace-preview-grid" style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'minmax(0, 1.1fr) minmax(0, 0.9fr)' }}>
-          <div style={{ display: 'grid', gap: '0.85rem' }}>
-            {selectedListing?.photoUrl ? (
+        <div className="marketplace-preview-grid">
+          <div className="marketplace-modal-main-column">
+            {selectedListingPhotoUrl && !modalImageFailed ? (
               <img
-                src={selectedListing.photoUrl}
+                src={selectedListingPhotoUrl}
                 alt={selectedListing.title || 'Anúncio'}
-                style={{ width: '100%', borderRadius: '1rem', border: '1px solid var(--studio-line)', objectFit: 'cover', aspectRatio: '4 / 3' }}
+                className="marketplace-modal-image"
+                onError={() => setModalImageFailed(true)}
               />
             ) : (
-              <div
-                style={{
-                  alignItems: 'center',
-                  aspectRatio: '4 / 3',
-                  background: 'var(--studio-soft-bg)',
-                  border: '1px dashed var(--studio-soft-line)',
-                  borderRadius: '1rem',
-                  display: 'grid',
-                  justifyItems: 'center',
-                  color: 'var(--studio-muted)',
-                }}
-              >
+              <div className="marketplace-modal-image-empty">
                 Sem imagem
               </div>
             )}
 
-            <div style={{ display: 'grid', gap: '0.5rem' }}>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
+            <div className="marketplace-modal-meta-block">
+              <div className="marketplace-modal-meta-head">
                 <Badge variant={selectedStatusTone}>{getStatusLabel(selectedListing)}</Badge>
-                <span style={{ color: 'var(--studio-muted)' }}>{formatMoney(selectedListing?.price)}</span>
+                <span className="marketplace-modal-price">{formatMoney(selectedListing?.price)}</span>
               </div>
 
-              <p style={{ margin: 0, color: 'var(--studio-muted)' }}>{selectedListing?.description || 'Sem descrição adicional.'}</p>
+              <p className="marketplace-modal-description">{selectedListing?.description || 'Sem descrição adicional.'}</p>
 
               {selectedListing?.rejectionReason ? (
-                <div className="soft-box error" style={{ marginTop: '0.25rem' }}>
+                <div className="soft-box error marketplace-modal-registered-reason">
                   <strong>Motivo registado:</strong> {selectedListing.rejectionReason}
                 </div>
               ) : null}
             </div>
           </div>
 
-          <div style={{ display: 'grid', gap: '0.85rem' }}>
+          <div className="marketplace-modal-side-column">
             <div className="soft-box">
               <strong>Vendedor</strong>
-              <p style={{ margin: '0.35rem 0 0' }}>
+              <p className="marketplace-modal-line-first">
                 {[selectedListing?.seller?.firstName, selectedListing?.seller?.lastName].filter(Boolean).join(' ') || '—'}
               </p>
-              <p style={{ margin: '0.1rem 0 0', color: 'var(--studio-muted)' }}>
+              <p className="marketplace-modal-line-subtle">
                 {selectedListing?.seller?.email || '—'}
               </p>
-              <p style={{ margin: '0.1rem 0 0', color: 'var(--studio-muted)' }}>
+              <p className="marketplace-modal-line-subtle">
                 {selectedListing?.seller?.phoneNumber || '—'}
               </p>
             </div>
 
             <div className="soft-box">
               <strong>Detalhes do anúncio</strong>
-              <p style={{ margin: '0.35rem 0 0' }}>
+              <p className="marketplace-modal-line-first">
                 Categoria: {selectedListing?.category?.categoryName || '—'}
               </p>
-              <p style={{ margin: '0.1rem 0 0' }}>
+              <p className="marketplace-modal-line-regular">
                 Estado: {selectedListing?.condition?.conditionName || '—'}
               </p>
-              <p style={{ margin: '0.1rem 0 0' }}>
+              <p className="marketplace-modal-line-regular">
                 Localização: {selectedListing?.location || '—'}
               </p>
-              <p style={{ margin: '0.1rem 0 0' }}>
+              <p className="marketplace-modal-line-regular">
                 Publicado: {formatDateTime(selectedListing?.createdAt)}
               </p>
             </div>
 
-            <label style={{ display: 'grid', gap: '0.45rem' }}>
-              <span style={{ color: 'var(--studio-ink)', fontWeight: 600 }}>Motivo da rejeição</span>
-              <textarea
-                ref={reasonRef}
-                rows={5}
-                value={rejectionReason}
-                onChange={(event) => setRejectionReason(event.target.value)}
-                placeholder="Descreve claramente o motivo para rejeitar este anúncio"
-                style={{
-                  background: 'var(--studio-field-bg)',
-                  border: '1px solid var(--studio-field-line)',
-                  borderRadius: '0.85rem',
-                  color: 'var(--studio-ink)',
-                  font: 'inherit',
-                  padding: '0.8rem 0.9rem',
-                  resize: 'vertical',
-                  width: '100%',
-                }}
-              />
-              <span style={{ color: 'var(--studio-muted)', fontSize: '0.85rem' }}>
-                Obrigatório quando a decisão for rejeitar.
-              </span>
-            </label>
+            {isRejectMode ? (
+              <label className="marketplace-rejection-panel">
+                <span className="marketplace-rejection-title">Motivo da rejeição</span>
+                <textarea
+                  ref={reasonRef}
+                  rows={5}
+                  value={rejectionReason}
+                  onChange={(event) => setRejectionReason(event.target.value)}
+                  placeholder="Descreve claramente o motivo para rejeitar este anúncio"
+                />
+                <span className="marketplace-rejection-help">Obrigatório para confirmar rejeição.</span>
+              </label>
+            ) : null}
           </div>
         </div>
       </Modal>

--- a/src/pages/admin/MarketplaceModerationPage.jsx
+++ b/src/pages/admin/MarketplaceModerationPage.jsx
@@ -1,0 +1,754 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import adminMarketplaceService from '../../services/adminMarketplaceService'
+import Badge from '../../components/ui/Badge'
+import Input from '../../components/ui/Input'
+import Modal from '../../components/ui/Modal'
+import Table from '../../components/ui/Table'
+import '../admin-studios.css'
+
+const navigationItems = [
+  { href: '/admin/dashboard', label: 'Painel' },
+  { href: '/admin/validations', label: 'Validações' },
+  { href: '/admin/studios', label: 'Estúdios' },
+  { href: '/admin/users', label: 'Utilizadores' },
+  { href: '/admin/lostfound', label: 'Perdidos e Achados' },
+  { href: '/admin/inventory', label: 'Inventário da Escola' },
+  { href: '/admin/marketplace', label: 'Marketplace' },
+  { href: '/admin/finance', label: 'Finanças' },
+  { href: '/admin/audit', label: 'Auditoria' },
+]
+
+const statusOptions = [
+  { value: 'all', label: 'Todos' },
+  { value: 'pending', label: 'Pendentes' },
+  { value: 'approved', label: 'Aprovados' },
+  { value: 'rejected', label: 'Rejeitados' },
+  { value: 'removed', label: 'Removidos' },
+]
+
+function formatMoney(value) {
+  const numeric = Number(value)
+
+  if (Number.isNaN(numeric)) {
+    return '—'
+  }
+
+  return new Intl.NumberFormat('pt-PT', {
+    currency: 'EUR',
+    style: 'currency',
+  }).format(numeric)
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return '—'
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return '—'
+  }
+
+  return parsed.toLocaleString('pt-PT', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  })
+}
+
+function getStatusTone(statusName) {
+  const normalized = String(statusName || '').trim().toLowerCase()
+
+  if (normalized.includes('pend')) {
+    return 'warning'
+  }
+
+  if (normalized.includes('rejeit') || normalized.includes('reject')) {
+    return 'danger'
+  }
+
+  if (normalized.includes('aprov') || normalized.includes('approved') || normalized.includes('active')) {
+    return 'success'
+  }
+
+  return 'neutral'
+}
+
+function getStatusLabel(listing) {
+  return listing?.status?.statusName || (listing?.isActive ? 'Ativo' : 'Inativo')
+}
+
+function statusMatchesFilter(listing, statusFilter) {
+  if (statusFilter === 'all') {
+    return true
+  }
+
+  const statusName = String(listing?.status?.statusName || '').trim().toLowerCase()
+
+  if (statusFilter === 'pending') {
+    return statusName.includes('pend')
+  }
+
+  if (statusFilter === 'approved') {
+    return statusName.includes('aprov') || statusName.includes('approved') || statusName.includes('active')
+  }
+
+  if (statusFilter === 'rejected') {
+    return statusName.includes('rejeit') || statusName.includes('reject')
+  }
+
+  if (statusFilter === 'removed') {
+    return statusName.includes('remov') || statusName.includes('hidden') || statusName.includes('inactive')
+  }
+
+  return true
+}
+
+function marketplaceSearchText(listing) {
+  return [
+    listing?.title,
+    listing?.description,
+    listing?.location,
+    listing?.category?.categoryName,
+    listing?.seller?.firstName,
+    listing?.seller?.lastName,
+    listing?.seller?.email,
+    listing?.status?.statusName,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+export default function MarketplaceModerationPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { logout, user } = useAuth()
+  const reasonRef = useRef(null)
+
+  const [isMobile, setIsMobile] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [listings, setListings] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadingError, setLoadingError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [error, setError] = useState('')
+  const [selectedListing, setSelectedListing] = useState(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [rejectionReason, setRejectionReason] = useState('')
+  const [submittingAction, setSubmittingAction] = useState('')
+  const [filters, setFilters] = useState({
+    search: '',
+    location: '',
+    minPrice: '',
+    maxPrice: '',
+    status: 'all',
+  })
+
+  const displayName = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || user?.email || 'Utilizador'
+  const sidebarActivePath = location.pathname
+  const sidebarHidden = isMobile || sidebarCollapsed
+  const appShellClassName = ['app-shell', sidebarHidden ? 'sidebar-hidden' : '']
+    .filter(Boolean)
+    .join(' ')
+  const sidebarClassName = ['sidebar', isMobile && mobileOpen ? 'open' : '']
+    .filter(Boolean)
+    .join(' ')
+  const sidebarToggleSymbol = isMobile
+    ? mobileOpen ? '✕' : '☰'
+    : sidebarCollapsed ? '▶' : '◀'
+  const sidebarToggleLabel = isMobile
+    ? mobileOpen ? 'Fechar menu lateral' : 'Abrir menu lateral'
+    : sidebarCollapsed ? 'Mostrar barra lateral' : 'Esconder barra lateral'
+
+  const loadListings = useCallback(async () => {
+    setLoading(true)
+    setLoadingError('')
+
+    try {
+      const payload = await adminMarketplaceService.listListings()
+      setListings(Array.isArray(payload) ? payload : [])
+    } catch (requestError) {
+      setLoadingError(requestError?.response?.data?.error || 'Não foi possível carregar os anúncios do marketplace.')
+      setListings([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadListings()
+  }, [loadListings])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 1024px)')
+
+    const updateLayout = () => {
+      setIsMobile(mediaQuery.matches)
+
+      if (!mediaQuery.matches) {
+        setMobileOpen(false)
+      }
+    }
+
+    updateLayout()
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updateLayout)
+      return () => mediaQuery.removeEventListener('change', updateLayout)
+    }
+
+    mediaQuery.addListener(updateLayout)
+    return () => mediaQuery.removeListener(updateLayout)
+  }, [])
+
+  useEffect(() => {
+    document.body.classList.add('studio-page')
+
+    return () => {
+      document.body.classList.remove('studio-page')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isModalOpen && selectedListing) {
+      reasonRef.current?.focus?.()
+    }
+  }, [isModalOpen, selectedListing])
+
+  const filteredListings = useMemo(() => {
+    const search = filters.search.trim().toLowerCase()
+    const locationTerm = filters.location.trim().toLowerCase()
+    const minPrice = filters.minPrice === '' ? null : Number(filters.minPrice)
+    const maxPrice = filters.maxPrice === '' ? null : Number(filters.maxPrice)
+
+    return listings.filter((listing) => {
+      if (!statusMatchesFilter(listing, filters.status)) {
+        return false
+      }
+
+      if (search && !marketplaceSearchText(listing).includes(search)) {
+        return false
+      }
+
+      if (locationTerm && !String(listing.location || '').toLowerCase().includes(locationTerm)) {
+        return false
+      }
+
+      if (minPrice !== null && Number(listing.price) < minPrice) {
+        return false
+      }
+
+      if (maxPrice !== null && Number(listing.price) > maxPrice) {
+        return false
+      }
+
+      return true
+    })
+  }, [filters, listings])
+
+  const counts = useMemo(() => {
+    const summary = { all: listings.length, pending: 0, approved: 0, rejected: 0, removed: 0 }
+
+    for (const listing of listings) {
+      const statusName = String(listing?.status?.statusName || '').trim().toLowerCase()
+
+      if (statusName.includes('pend')) {
+        summary.pending += 1
+      } else if (statusName.includes('rejeit') || statusName.includes('reject')) {
+        summary.rejected += 1
+      } else if (statusName.includes('remov') || statusName.includes('inactive') || statusName.includes('hidden')) {
+        summary.removed += 1
+      } else if (statusName.includes('aprov') || statusName.includes('approved') || statusName.includes('active')) {
+        summary.approved += 1
+      }
+    }
+
+    return summary
+  }, [listings])
+
+  const selectedStatusTone = getStatusTone(selectedListing?.status?.statusName)
+
+  const updateFilter = (field, value) => {
+    setFilters((current) => ({
+      ...current,
+      [field]: value,
+    }))
+  }
+
+  const openListing = (listing, shouldSelectReject = false) => {
+    setSelectedListing(listing)
+    setRejectionReason(listing?.rejectionReason || '')
+    setIsModalOpen(true)
+
+    if (shouldSelectReject) {
+      setTimeout(() => {
+        reasonRef.current?.focus?.()
+      }, 0)
+    }
+  }
+
+  const closeModal = () => {
+    setIsModalOpen(false)
+    setSelectedListing(null)
+    setRejectionReason('')
+  }
+
+  async function handleModeration(action, listing, payloadReason = '') {
+    if (!listing || submittingAction) {
+      return
+    }
+
+    setSubmittingAction(action)
+    setError('')
+    setNotice('')
+
+    try {
+      if (action === 'approve') {
+        await adminMarketplaceService.approveListing(listing.listingId)
+        setNotice(`Anúncio "${listing.title}" aprovado.`)
+      } else if (action === 'reject') {
+        const reason = String(payloadReason || '').trim()
+
+        if (!reason) {
+          setError('Indica um motivo de rejeição antes de continuar.')
+          reasonRef.current?.focus?.()
+          return
+        }
+
+        await adminMarketplaceService.rejectListing(listing.listingId, reason)
+        setNotice(`Anúncio "${listing.title}" rejeitado.`)
+      } else if (action === 'delete') {
+        const confirmed = window.confirm(`Eliminar o anúncio "${listing.title}"?`)
+
+        if (!confirmed) {
+          return
+        }
+
+        await adminMarketplaceService.deleteListing(listing.listingId)
+        setNotice(`Anúncio "${listing.title}" removido.`)
+      }
+
+      closeModal()
+      await loadListings()
+    } catch (requestError) {
+      setError(requestError?.response?.data?.error || 'Não foi possível concluir a ação de moderação.')
+    } finally {
+      setSubmittingAction('')
+    }
+  }
+
+  async function handleLogout(event) {
+    event.preventDefault()
+
+    try {
+      await logout()
+    } finally {
+      navigate('/login', { replace: true })
+    }
+  }
+
+  const handleSidebarToggle = () => {
+    if (isMobile) {
+      setMobileOpen((currentValue) => !currentValue)
+      return
+    }
+
+    setSidebarCollapsed((currentValue) => !currentValue)
+  }
+
+  const handleMobileNavClick = () => {
+    if (isMobile) {
+      setMobileOpen(false)
+    }
+  }
+
+  return (
+    <div className={appShellClassName}>
+      {isMobile && mobileOpen ? (
+        <button
+          type="button"
+          className="sidebar-overlay"
+          aria-label="Fechar navegação lateral"
+          onClick={() => setMobileOpen(false)}
+        />
+      ) : null}
+
+      <aside className={sidebarClassName} id="sidebar">
+        <div className="brand">
+          <span className="brand-dot" />
+          <div>
+            <h1>gestArtes</h1>
+            <p>{displayName}</p>
+          </div>
+        </div>
+
+        <div className="nav-group">
+          <h2>Gestão</h2>
+
+          {navigationItems.map((item) => (
+            <Link
+              key={item.href}
+              className={`nav-link${sidebarActivePath === item.href ? ' active' : ''}`}
+              to={item.href}
+              onClick={handleMobileNavClick}
+            >
+              {item.label}
+            </Link>
+          ))}
+
+          <a className="nav-link" href="/login" title={`Terminar sessão de ${displayName}`} onClick={handleLogout}>
+            Terminar Sessão
+          </a>
+        </div>
+      </aside>
+
+      <main className="main">
+        <header className="topbar">
+          <div className="topbar-left">
+            <div className="topbar-heading">
+              <button
+                type="button"
+                className="sidebar-toggle-btn"
+                aria-label={sidebarToggleLabel}
+                onClick={handleSidebarToggle}
+              >
+                {sidebarToggleSymbol}
+              </button>
+              <h2>Moderação do Marketplace</h2>
+            </div>
+            <p>Pesquisa anúncios, revisa o conteúdo e aprova ou rejeita antes da publicação.</p>
+          </div>
+
+          <div className="topbar-right">
+            <span className="pill">{counts.pending} pendentes</span>
+          </div>
+        </header>
+
+        <section className="content-grid" style={{ gap: '1rem' }}>
+          <div className="content-grid" style={{ gridTemplateColumns: 'repeat(4, minmax(0, 1fr))' }}>
+            <article className="panel">
+              <h3>Todos</h3>
+              <strong style={{ fontSize: '1.7rem' }}>{counts.all}</strong>
+            </article>
+            <article className="panel">
+              <h3>Pendentes</h3>
+              <strong style={{ fontSize: '1.7rem' }}>{counts.pending}</strong>
+            </article>
+            <article className="panel">
+              <h3>Aprovados</h3>
+              <strong style={{ fontSize: '1.7rem' }}>{counts.approved}</strong>
+            </article>
+            <article className="panel">
+              <h3>Rejeitados</h3>
+              <strong style={{ fontSize: '1.7rem' }}>{counts.rejected}</strong>
+            </article>
+          </div>
+
+          {notice ? (
+            <div className="soft-box" role="status" aria-live="polite">
+              {notice}
+            </div>
+          ) : null}
+
+          {loadingError ? (
+            <div className="soft-box error" role="alert">
+              {loadingError}
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="soft-box error" role="alert">
+              {error}
+            </div>
+          ) : null}
+
+          <article className="panel">
+            <div className="panel-header">
+              <h3>Feed e queue de moderação</h3>
+              <button type="button" className="ghost-btn" onClick={() => void loadListings()}>
+                Atualizar
+              </button>
+            </div>
+
+            <div className="form-grid two">
+              <Input
+                label="Pesquisar"
+                value={filters.search}
+                onChange={(event) => updateFilter('search', event.target.value)}
+                placeholder="Título, descrição, vendedor ou estado"
+              />
+
+              <Input
+                label="Localização"
+                value={filters.location}
+                onChange={(event) => updateFilter('location', event.target.value)}
+                placeholder="Ex.: Viana do Castelo"
+              />
+
+              <Input
+                label="Preço mínimo"
+                type="number"
+                min="0"
+                value={filters.minPrice}
+                onChange={(event) => updateFilter('minPrice', event.target.value)}
+                placeholder="0"
+              />
+
+              <Input
+                label="Preço máximo"
+                type="number"
+                min="0"
+                value={filters.maxPrice}
+                onChange={(event) => updateFilter('maxPrice', event.target.value)}
+                placeholder="100"
+              />
+            </div>
+
+            <div className="marketplace-status-tabs" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '0.85rem' }}>
+              {statusOptions.map((option) => {
+                const active = filters.status === option.value
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={active ? 'pill' : 'ghost-btn'}
+                    onClick={() => updateFilter('status', option.value)}
+                  >
+                    {option.label}
+                  </button>
+                )
+              })}
+            </div>
+
+            <div className="table-wrap" style={{ marginTop: '1rem' }}>
+              {loading ? (
+                <div className="soft-box">A carregar anúncios...</div>
+              ) : (
+                <Table
+                  columns={[
+                    {
+                      header: 'Anúncio',
+                      key: 'title',
+                      render: (listing) => (
+                        <div style={{ display: 'grid', gap: '0.25rem' }}>
+                          <strong>{listing.title || 'Sem título'}</strong>
+                          <span style={{ color: 'var(--studio-muted)', fontSize: '0.85rem' }}>
+                            {listing.category?.categoryName || 'Categoria geral'} · {formatDateTime(listing.createdAt)}
+                          </span>
+                        </div>
+                      ),
+                    },
+                    {
+                      header: 'Vendedor',
+                      key: 'seller',
+                      render: (listing) => (
+                        <div style={{ display: 'grid', gap: '0.2rem' }}>
+                          <strong>{[listing.seller?.firstName, listing.seller?.lastName].filter(Boolean).join(' ') || '—'}</strong>
+                          <span style={{ color: 'var(--studio-muted)', fontSize: '0.85rem' }}>
+                            {listing.seller?.email || '—'}
+                          </span>
+                        </div>
+                      ),
+                    },
+                    {
+                      header: 'Preço',
+                      key: 'price',
+                      align: 'right',
+                      render: (listing) => formatMoney(listing.price),
+                    },
+                    {
+                      header: 'Localização',
+                      key: 'location',
+                      render: (listing) => listing.location || '—',
+                    },
+                    {
+                      header: 'Estado',
+                      key: 'status',
+                      render: (listing) => (
+                        <Badge variant={getStatusTone(listing.status?.statusName)}>
+                          {getStatusLabel(listing)}
+                        </Badge>
+                      ),
+                    },
+                  ]}
+                  rows={filteredListings}
+                  getRowKey={(listing) => listing.listingId}
+                  emptyState="Não existem anúncios com os filtros atuais."
+                  renderRowActions={(listing) => (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                      <button type="button" className="ghost-btn" onClick={() => openListing(listing)}>
+                        Ver
+                      </button>
+                      <button
+                        type="button"
+                        className="ghost-btn"
+                        disabled={submittingAction === 'approve' || getStatusTone(listing.status?.statusName) === 'success'}
+                        onClick={() => void handleModeration('approve', listing)}
+                      >
+                        Aprovar
+                      </button>
+                      <button
+                        type="button"
+                        className="ghost-btn"
+                        disabled={submittingAction === 'reject'}
+                        onClick={() => openListing(listing, true)}
+                      >
+                        Rejeitar
+                      </button>
+                      <button
+                        type="button"
+                        className="danger-btn"
+                        disabled={submittingAction === 'delete'}
+                        onClick={() => void handleModeration('delete', listing)}
+                      >
+                        Apagar
+                      </button>
+                    </div>
+                  )}
+                />
+              )}
+            </div>
+          </article>
+        </section>
+      </main>
+
+      <Modal
+        open={isModalOpen}
+        onClose={closeModal}
+        title={selectedListing?.title || 'Detalhe do anúncio'}
+        description="Revisa o anúncio, consulta a informação enviada e decide o estado de publicação."
+        size="xl"
+        footer={
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              className="ghost-btn"
+              disabled={submittingAction === 'approve'}
+              onClick={() => void handleModeration('approve', selectedListing)}
+            >
+              Aprovar
+            </button>
+            <button
+              type="button"
+              className="ghost-btn"
+              disabled={submittingAction === 'reject'}
+              onClick={() => void handleModeration('reject', selectedListing, rejectionReason)}
+            >
+              Rejeitar
+            </button>
+            <button
+              type="button"
+              className="danger-btn"
+              disabled={submittingAction === 'delete'}
+              onClick={() => void handleModeration('delete', selectedListing)}
+            >
+              Apagar
+            </button>
+          </div>
+        }
+      >
+        <div className="marketplace-preview-grid" style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'minmax(0, 1.1fr) minmax(0, 0.9fr)' }}>
+          <div style={{ display: 'grid', gap: '0.85rem' }}>
+            {selectedListing?.photoUrl ? (
+              <img
+                src={selectedListing.photoUrl}
+                alt={selectedListing.title || 'Anúncio'}
+                style={{ width: '100%', borderRadius: '1rem', border: '1px solid var(--studio-line)', objectFit: 'cover', aspectRatio: '4 / 3' }}
+              />
+            ) : (
+              <div
+                style={{
+                  alignItems: 'center',
+                  aspectRatio: '4 / 3',
+                  background: 'var(--studio-soft-bg)',
+                  border: '1px dashed var(--studio-soft-line)',
+                  borderRadius: '1rem',
+                  display: 'grid',
+                  justifyItems: 'center',
+                  color: 'var(--studio-muted)',
+                }}
+              >
+                Sem imagem
+              </div>
+            )}
+
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
+                <Badge variant={selectedStatusTone}>{getStatusLabel(selectedListing)}</Badge>
+                <span style={{ color: 'var(--studio-muted)' }}>{formatMoney(selectedListing?.price)}</span>
+              </div>
+
+              <p style={{ margin: 0, color: 'var(--studio-muted)' }}>{selectedListing?.description || 'Sem descrição adicional.'}</p>
+
+              {selectedListing?.rejectionReason ? (
+                <div className="soft-box error" style={{ marginTop: '0.25rem' }}>
+                  <strong>Motivo registado:</strong> {selectedListing.rejectionReason}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gap: '0.85rem' }}>
+            <div className="soft-box">
+              <strong>Vendedor</strong>
+              <p style={{ margin: '0.35rem 0 0' }}>
+                {[selectedListing?.seller?.firstName, selectedListing?.seller?.lastName].filter(Boolean).join(' ') || '—'}
+              </p>
+              <p style={{ margin: '0.1rem 0 0', color: 'var(--studio-muted)' }}>
+                {selectedListing?.seller?.email || '—'}
+              </p>
+              <p style={{ margin: '0.1rem 0 0', color: 'var(--studio-muted)' }}>
+                {selectedListing?.seller?.phoneNumber || '—'}
+              </p>
+            </div>
+
+            <div className="soft-box">
+              <strong>Detalhes do anúncio</strong>
+              <p style={{ margin: '0.35rem 0 0' }}>
+                Categoria: {selectedListing?.category?.categoryName || '—'}
+              </p>
+              <p style={{ margin: '0.1rem 0 0' }}>
+                Estado: {selectedListing?.condition?.conditionName || '—'}
+              </p>
+              <p style={{ margin: '0.1rem 0 0' }}>
+                Localização: {selectedListing?.location || '—'}
+              </p>
+              <p style={{ margin: '0.1rem 0 0' }}>
+                Publicado: {formatDateTime(selectedListing?.createdAt)}
+              </p>
+            </div>
+
+            <label style={{ display: 'grid', gap: '0.45rem' }}>
+              <span style={{ color: 'var(--studio-ink)', fontWeight: 600 }}>Motivo da rejeição</span>
+              <textarea
+                ref={reasonRef}
+                rows={5}
+                value={rejectionReason}
+                onChange={(event) => setRejectionReason(event.target.value)}
+                placeholder="Descreve claramente o motivo para rejeitar este anúncio"
+                style={{
+                  background: 'var(--studio-field-bg)',
+                  border: '1px solid var(--studio-field-line)',
+                  borderRadius: '0.85rem',
+                  color: 'var(--studio-ink)',
+                  font: 'inherit',
+                  padding: '0.8rem 0.9rem',
+                  resize: 'vertical',
+                  width: '100%',
+                }}
+              />
+              <span style={{ color: 'var(--studio-muted)', fontSize: '0.85rem' }}>
+                Obrigatório quando a decisão for rejeitar.
+              </span>
+            </label>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/src/pages/admin/marketplace-moderation.css
+++ b/src/pages/admin/marketplace-moderation.css
@@ -1,0 +1,187 @@
+.moderation-action-btn {
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.88rem;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  min-height: 36px;
+  padding: 0.62rem 0.8rem;
+  transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
+}
+
+.moderation-action-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(31, 28, 46, 0.12);
+}
+
+.moderation-action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  transform: none;
+  box-shadow: none;
+}
+
+.moderation-action-btn.neutral {
+  border: 1px solid var(--studio-ghost-line);
+  background: var(--studio-field-bg);
+  color: var(--studio-ghost-ink);
+}
+
+.moderation-action-btn.approve {
+  border: 1px solid #67bbb3;
+  background: linear-gradient(135deg, #ecfbf8 0%, #def6f1 100%);
+  color: #0c6d65;
+}
+
+.moderation-action-btn.reject {
+  border: 1px solid #f1c09b;
+  background: linear-gradient(135deg, #fff7f0 0%, #ffefe1 100%);
+  color: #7d4a2a;
+}
+
+.moderation-action-btn.delete {
+  border: 1px solid var(--studio-danger-line);
+  background: linear-gradient(135deg, #fff5f7 0%, #ffecef 100%);
+  color: var(--studio-danger-ink);
+}
+
+.marketplace-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.marketplace-modal-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.7rem;
+}
+
+.marketplace-preview-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+}
+
+.marketplace-modal-main-column,
+.marketplace-modal-side-column {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.marketplace-modal-image,
+.marketplace-modal-image-empty {
+  border-radius: 14px;
+  aspect-ratio: 4 / 3;
+}
+
+.marketplace-modal-image {
+  width: 100%;
+  border: 1px solid var(--studio-line);
+  object-fit: cover;
+  display: block;
+}
+
+.marketplace-modal-image-empty {
+  align-items: center;
+  background: var(--studio-soft-bg);
+  border: 1px dashed var(--studio-soft-line);
+  color: var(--studio-muted);
+  display: grid;
+  justify-items: center;
+}
+
+.marketplace-modal-meta-block {
+  border: 1px solid var(--studio-line);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.marketplace-modal-meta-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.marketplace-modal-price {
+  color: var(--studio-muted);
+  font-weight: 600;
+}
+
+.marketplace-modal-description {
+  color: var(--studio-muted);
+  margin: 0;
+  line-height: 1.45;
+}
+
+.marketplace-modal-registered-reason {
+  margin-top: 0.15rem;
+}
+
+.marketplace-modal-line-first {
+  margin: 0.35rem 0 0;
+}
+
+.marketplace-modal-line-regular {
+  margin: 0.15rem 0 0;
+}
+
+.marketplace-modal-line-subtle {
+  margin: 0.12rem 0 0;
+  color: var(--studio-muted);
+}
+
+.marketplace-rejection-panel {
+  border: 1px solid #f1c09b;
+  border-radius: 12px;
+  background: #fff9f3;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.72rem;
+}
+
+.marketplace-rejection-title {
+  color: #7d4a2a;
+  font-weight: 700;
+}
+
+.marketplace-rejection-panel textarea {
+  background: var(--studio-field-bg);
+  border: 1px solid var(--studio-field-line);
+  border-radius: 10px;
+  color: var(--studio-ink);
+  font: inherit;
+  min-height: 110px;
+  padding: 0.8rem 0.9rem;
+  resize: vertical;
+  width: 100%;
+}
+
+.marketplace-rejection-help {
+  color: #8d6544;
+  font-size: 0.83rem;
+}
+
+.marketplace-rejection-hint {
+  margin: 0;
+}
+
+@media (max-width: 980px) {
+  .marketplace-preview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-modal-footer-actions {
+    justify-content: stretch;
+  }
+
+  .marketplace-modal-footer-actions .moderation-action-btn {
+    flex: 1 1 100%;
+  }
+}

--- a/src/services/adminMarketplaceService.js
+++ b/src/services/adminMarketplaceService.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { resolveMarketplacePhotoUrl } from '../utils/marketplace-photo-url'
 
 function toNumber(value) {
   const numeric = Number(value)
@@ -32,7 +33,7 @@ function mapListing(entry) {
           statusName: String(entry.status.statusName ?? entry.status.StatusName ?? '').trim(),
         }
       : null,
-    photoUrl: String(entry?.photoUrl ?? entry?.PhotoURL ?? '').trim(),
+    photoUrl: resolveMarketplacePhotoUrl(entry?.photoUrl ?? entry?.PhotoURL ?? ''),
     location: String(entry?.location ?? entry?.Location ?? '').trim(),
     createdAt: entry?.createdAt ?? entry?.CreatedAt ?? null,
     isActive: Boolean(entry?.isActive ?? entry?.IsActive),

--- a/src/services/adminMarketplaceService.js
+++ b/src/services/adminMarketplaceService.js
@@ -1,0 +1,74 @@
+import api from './api'
+
+function toNumber(value) {
+  const numeric = Number(value)
+
+  return Number.isNaN(numeric) ? 0 : numeric
+}
+
+function mapListing(entry) {
+  return {
+    listingId: entry?.listingId ?? entry?.MarketplaceItemID ?? '',
+    sellerId: entry?.sellerId ?? entry?.SellerID ?? '',
+    title: String(entry?.title ?? entry?.Title ?? '').trim(),
+    description: String(entry?.description ?? entry?.Description ?? '').trim(),
+    rejectionReason: String(entry?.rejectionReason ?? entry?.RejectionReason ?? '').trim(),
+    price: toNumber(entry?.price ?? entry?.Price),
+    category: entry?.category
+      ? {
+          categoryId: entry.category.categoryId ?? entry.category.CategoryID ?? '',
+          categoryName: String(entry.category.categoryName ?? entry.category.CategoryName ?? '').trim(),
+        }
+      : null,
+    condition: entry?.condition
+      ? {
+          conditionId: entry.condition.conditionId ?? entry.condition.ConditionID ?? '',
+          conditionName: String(entry.condition.conditionName ?? entry.condition.ConditionName ?? '').trim(),
+        }
+      : null,
+    status: entry?.status
+      ? {
+          statusId: entry.status.statusId ?? entry.status.StatusID ?? '',
+          statusName: String(entry.status.statusName ?? entry.status.StatusName ?? '').trim(),
+        }
+      : null,
+    photoUrl: String(entry?.photoUrl ?? entry?.PhotoURL ?? '').trim(),
+    location: String(entry?.location ?? entry?.Location ?? '').trim(),
+    createdAt: entry?.createdAt ?? entry?.CreatedAt ?? null,
+    isActive: Boolean(entry?.isActive ?? entry?.IsActive),
+    seller: entry?.seller
+      ? {
+          userId: entry.seller.userId ?? entry.seller.UserID ?? '',
+          firstName: String(entry.seller.firstName ?? entry.seller.FirstName ?? '').trim(),
+          lastName: String(entry.seller.lastName ?? entry.seller.LastName ?? '').trim(),
+          email: String(entry.seller.email ?? entry.seller.Email ?? '').trim(),
+          phoneNumber: String(entry.seller.phoneNumber ?? entry.seller.PhoneNumber ?? '').trim(),
+        }
+      : null,
+  }
+}
+
+const adminMarketplaceService = {
+  async listListings(filters = {}) {
+    const response = await api.get('/admin/marketplace/listings', { params: filters })
+    const listings = Array.isArray(response.data?.listings) ? response.data.listings : []
+
+    return listings.map(mapListing)
+  },
+
+  async approveListing(listingId) {
+    const response = await api.patch(`/admin/marketplace/listings/${listingId}/approve`)
+    return mapListing(response.data?.listing ?? response.data)
+  },
+
+  async rejectListing(listingId, reason) {
+    const response = await api.patch(`/admin/marketplace/listings/${listingId}/reject`, { reason })
+    return mapListing(response.data?.listing ?? response.data)
+  },
+
+  async deleteListing(listingId) {
+    await api.delete(`/admin/marketplace/listings/${listingId}`)
+  },
+}
+
+export default adminMarketplaceService

--- a/src/services/marketplace.js
+++ b/src/services/marketplace.js
@@ -1,6 +1,14 @@
 import api from './api'
 
-function appendField(formData, key, value) {
+function appendField(payload, key, value) {
+  if (value === undefined || value === null || value === '') {
+    return
+  }
+
+  payload[key] = value
+}
+
+function appendFieldToFormData(formData, key, value) {
   if (value === undefined || value === null || value === '') {
     return
   }
@@ -8,14 +16,26 @@ function appendField(formData, key, value) {
   formData.append(key, String(value))
 }
 
-function buildFormData(values, file) {
+function buildPayload(values) {
+  const payload = {}
+  appendField(payload, 'title', values.title)
+  appendField(payload, 'description', values.description)
+  appendField(payload, 'price', values.price)
+  appendField(payload, 'conditionId', values.conditionId)
+  appendField(payload, 'categoryId', values.categoryId)
+  appendField(payload, 'location', values.location)
+  appendField(payload, 'photoUrl', values.photoUrl)
+  return payload
+}
+
+function buildMultipartPayload(values, file) {
   const formData = new FormData()
-  appendField(formData, 'title', values.title)
-  appendField(formData, 'description', values.description)
-  appendField(formData, 'price', values.price)
-  appendField(formData, 'conditionId', values.conditionId)
-  appendField(formData, 'categoryId', values.categoryId)
-  appendField(formData, 'location', values.location)
+  appendFieldToFormData(formData, 'title', values.title)
+  appendFieldToFormData(formData, 'description', values.description)
+  appendFieldToFormData(formData, 'price', values.price)
+  appendFieldToFormData(formData, 'conditionId', values.conditionId)
+  appendFieldToFormData(formData, 'categoryId', values.categoryId)
+  appendFieldToFormData(formData, 'location', values.location)
 
   if (file) {
     formData.append('photo', file)
@@ -45,21 +65,25 @@ export async function getMyMarketplaceListings() {
 }
 
 export async function createMarketplaceListing(values, file) {
-  const response = await api.post('/marketplace/listings', buildFormData(values, file), {
+  const hasFile = Boolean(file)
+  const payload = hasFile ? buildMultipartPayload(values, file) : buildPayload(values)
+  const response = await api.post('/marketplace/listings', payload, hasFile ? {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
-  })
+  } : undefined)
 
   return response.data?.listing ?? null
 }
 
 export async function updateMarketplaceListing(listingId, values, file) {
-  const response = await api.patch(`/marketplace/listings/${listingId}`, buildFormData(values, file), {
+  const hasFile = Boolean(file)
+  const payload = hasFile ? buildMultipartPayload(values, file) : buildPayload(values)
+  const response = await api.patch(`/marketplace/listings/${listingId}`, payload, hasFile ? {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
-  })
+  } : undefined)
 
   return response.data?.listing ?? null
 }

--- a/src/utils/marketplace-photo-url.js
+++ b/src/utils/marketplace-photo-url.js
@@ -1,0 +1,39 @@
+function decodeHtmlEntities(value) {
+  return String(value || '')
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+}
+
+export function resolveMarketplacePhotoUrl(rawValue) {
+  const raw = decodeHtmlEntities(rawValue).trim().replace(/\\/g, '/')
+
+  if (!raw) {
+    return ''
+  }
+
+  if (/^(https?:|data:|blob:)/i.test(raw)) {
+    return raw
+  }
+
+  const apiBase = String(import.meta.env.VITE_API_URL || '').trim()
+
+  if (apiBase.startsWith('http://') || apiBase.startsWith('https://')) {
+    const apiOrigin = apiBase.replace(/\/api\/?$/i, '')
+
+    return raw.startsWith('/') ? `${apiOrigin}${raw}` : `${apiOrigin}/${raw}`
+  }
+
+  if (apiBase.startsWith('/')) {
+    if (raw.startsWith(apiBase + '/')) {
+      return raw
+    }
+
+    return raw.startsWith('/') ? `${apiBase}${raw}` : `${apiBase}/${raw}`
+  }
+
+  return raw.startsWith('/') ? raw : `/${raw}`
+}


### PR DESCRIPTION
Implements the admin marketplace moderation interface. It adds a dedicated admin moderation page and route, includes a searchable/filterable ads feed (location and price range), provides a preview modal with listing details and seller info, and supports approve/reject/delete actions with a required rejection comment flow integrated with the new backend moderation APIs.