### PR TITLE
Implement HTTPS support with secure cookies in Vite configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
-VITE_API_URL=http://localhost:3001
+#VITE_API_URL=http://localhost:3001
+
+# HTTPS — para dev com HTTPS no backend
+VITE_API_TARGET=https://localhost:3001
+VITE_SSL_KEY_PATH=../gestArtes-api/certs/gestartes.key
+VITE_SSL_CERT_PATH=../gestArtes-api/certs/gestartes.crt

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,38 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import fs from 'node:fs'
+import path from 'node:path'
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      '^/api(/.*)?$': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  function loadHttps() {
+    const keyPath = env.VITE_SSL_KEY_PATH
+    const certPath = env.VITE_SSL_CERT_PATH
+    if (!keyPath || !certPath) return undefined
+    try {
+      return {
+        key: fs.readFileSync(path.resolve(process.cwd(), keyPath)),
+        cert: fs.readFileSync(path.resolve(process.cwd(), certPath)),
+      }
+    } catch {
+      console.warn('[vite] SSL certs not found; running without HTTPS')
+      return undefined
+    }
+  }
+
+  return {
+    plugins: [react()],
+    server: {
+      https: loadHttps(),
+      proxy: {
+        '^/api(/.*)?$': {
+          target: env.VITE_API_TARGET || 'http://localhost:3001',
+          changeOrigin: true,
+          secure: false,
+          rewrite: (p) => p.replace(/^\/api/, ''),
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
- `vite.config.js` usa `loadEnv` para ler `VITE_SSL_KEY_PATH`/`VITE_SSL_CERT_PATH` e activar `server.https` automaticamente em dev
- Proxy do Vite lê o target da API a partir de `VITE_API_TARGET`

### Configuração

```env
# gestArtes-api/.env
SSL_KEY_PATH=certs/gestartes.key
SSL_CERT_PATH=certs/gestartes.crt

# gestArtes-web/.env
VITE_API_TARGET=https://localhost:3001
VITE_SSL_KEY_PATH=../gestArtes-api/certs/gestartes.key
VITE_SSL_CERT_PATH=../gestArtes-api/certs/gestartes.crt
```

Certificados de desenvolvimento gerados com:

```powershell
openssl req -x509 -newkey rsa:4096 -keyout certs/gestartes.key -out certs/gestartes.crt -days 365 -nodes -subj "/CN=localhost"
```