### PR TITLE
feat(sessions): implement session confirmation and tracking page for teachers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import DashboardPage from './pages/student/DashboardPage'
 import CoachingStudentPage from './pages/student/CoachingPage'
 import JoinRequestsTeacherView from './components/JoinRequestsTeacherView'
 import AdmissionRequestsPage from './pages/teacher/AdmissionRequestsPage'
+import SessionConfirmationPage from './pages/teacher/SessionConfirmationPage'
 import TeacherMarketplaceConversationsPage from './pages/teacher/TeacherMarketplaceConversationsPage'
 import InventoryPage from './pages/student/InventoryPage'
 import RentalCheckoutPage from './pages/student/RentalCheckoutPage'
@@ -218,6 +219,7 @@ function App() {
         <Route path="/teacher" element={<Navigate to="/teacher/dashboard" replace />} />
         <Route path="/teacher/dashboard" element={<TeacherDashboard />} />
         <Route path="/teacher/admission-requests" element={<AdmissionRequestsPage />} />
+        <Route path="/teacher/sessions/confirmation" element={<SessionConfirmationPage />} />
             <Route path="/teacher/marketplace/conversas" element={<TeacherMarketplaceConversationsPage />} />
       </Route>
 

--- a/src/pages/teacher/SessionConfirmationPage.css
+++ b/src/pages/teacher/SessionConfirmationPage.css
@@ -1,0 +1,499 @@
+.teacher-admission-requests .page-content {
+  display: grid;
+  gap: 14px;
+}
+
+.teacher-admission-requests .error-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #fff3f5;
+  border: 1px solid #f5c6cc;
+  border-radius: 12px;
+  padding: 12px 16px;
+  color: #8b2e39;
+  font-size: 0.88rem;
+}
+
+.teacher-admission-requests .retry-btn {
+  margin-left: auto;
+  border: 1px solid #e5b0b9;
+  border-radius: 999px;
+  background: #fff;
+  color: #8b2e39;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.teacher-admission-requests .retry-btn:hover {
+  background: #ffeef0;
+}
+
+.teacher-admission-requests .sessions-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.teacher-admission-requests .panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.teacher-admission-requests .empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--muted);
+}
+
+.teacher-admission-requests .empty-state-icon {
+  font-size: 2.5rem;
+  margin: 0 0 12px;
+  color: var(--teal);
+}
+
+.teacher-admission-requests .empty-state h3 {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-size: 1.1rem;
+}
+
+.teacher-admission-requests .empty-state p {
+  margin: 0;
+  font-size: 0.9rem;
+  max-width: 360px;
+  margin-inline: auto;
+}
+
+/* Session card */
+
+.teacher-admission-requests .session-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.teacher-admission-requests .session-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.teacher-admission-requests .session-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.teacher-admission-requests .session-ref {
+  font-weight: 700;
+  color: var(--ink);
+  font-size: 0.95rem;
+}
+
+.teacher-admission-requests .session-detail {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.teacher-admission-requests .session-detail::before {
+  content: '·';
+  margin-right: 8px;
+  color: var(--line);
+}
+
+.teacher-admission-requests .session-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #7a5c00;
+  background: #fff9e6;
+  border: 1px solid #f5e4a0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  display: inline-block;
+}
+
+/* Attendance list */
+
+.teacher-admission-requests .attendance-list {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.teacher-admission-requests .attendance-list-header {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 14px;
+  background: #f8f5fb;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.teacher-admission-requests .attendance-actions-col {
+  min-width: 130px;
+  text-align: right;
+}
+
+.teacher-admission-requests .attendance-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  transition: background 0.1s;
+}
+
+.teacher-admission-requests .attendance-row:last-child {
+  border-bottom: 0;
+}
+
+.teacher-admission-requests .attendance-row--noshow {
+  background: #fff7f5;
+}
+
+.teacher-admission-requests .attendance-row--present {
+  background: #f4fbf8;
+}
+
+.teacher-admission-requests .attendance-row--empty {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  padding: 16px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.teacher-admission-requests .attendance-student {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.teacher-admission-requests .attendance-name {
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.teacher-admission-requests .attendance-email {
+  font-size: 0.78rem;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.teacher-admission-requests .attendance-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  min-width: 130px;
+}
+
+.teacher-admission-requests .attendance-btn {
+  border-radius: 999px;
+  border: 1px solid;
+  padding: 5px 11px;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s, opacity 0.12s;
+}
+
+.teacher-admission-requests .attendance-btn--noshow {
+  border-color: #f5c0b0;
+  background: #fff5f0;
+  color: #8c3010;
+}
+
+.teacher-admission-requests .attendance-btn--noshow:hover {
+  background: #fce4d9;
+}
+
+.teacher-admission-requests .attendance-action-done {
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.teacher-admission-requests .attendance-action-done--noshow {
+  background: #fff0ee;
+  color: #8c3010;
+}
+
+.teacher-admission-requests .attendance-action-done--present {
+  background: #ecfbf4;
+  color: #0a6e4e;
+}
+
+/* Notification dropdown */
+
+.teacher-admission-requests .notif-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #e84a3a;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0 4px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.teacher-admission-requests .notif-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: min(360px, 90vw);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: 0 18px 36px rgba(20, 14, 30, 0.22);
+  z-index: 50;
+  overflow: hidden;
+}
+
+.teacher-admission-requests .notif-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--ink);
+}
+
+.teacher-admission-requests .notif-dropdown-body {
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.teacher-admission-requests .notif-empty {
+  margin: 0;
+  padding: 16px;
+  text-align: center;
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+
+.teacher-admission-requests .notif-error {
+  color: #8b2e39;
+}
+
+.teacher-admission-requests .notif-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.teacher-admission-requests .notif-item:last-child {
+  border-bottom: 0;
+}
+
+.teacher-admission-requests .notif-item--unread {
+  background: #f8f3ff;
+}
+
+.teacher-admission-requests .notif-title {
+  margin: 0 0 2px;
+  font-weight: 600;
+  font-size: 0.86rem;
+  color: var(--ink);
+}
+
+.teacher-admission-requests .notif-message {
+  margin: 0 0 4px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.teacher-admission-requests .notif-date {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+/* Sidebar footer */
+
+.teacher-admission-requests .sidebar-footer {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.teacher-admission-requests .sidebar-user {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ink);
+  padding: 8px 14px 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.teacher-admission-requests .logout-link {
+  color: #6d6480;
+}
+
+.teacher-admission-requests .logout-link:hover {
+  color: #2e2942;
+}
+
+.teacher-admission-requests .menu-toggle {
+  width: 34px;
+  height: 34px;
+  border: 1px solid #d7ccdf;
+  border-radius: 10px;
+  background: #fff;
+  color: #3f3558;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-family: inherit;
+}
+
+.teacher-admission-requests .menu-toggle:hover {
+  background: var(--lavender);
+}
+
+/* Modal form */
+
+.teacher-admission-requests .modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.teacher-admission-requests .modal-form-info {
+  background: #f8f5fb;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 0.88rem;
+  color: var(--ink);
+}
+
+.teacher-admission-requests .modal-form-info p {
+  margin: 0 0 4px;
+}
+
+.teacher-admission-requests .modal-form-info p:last-child {
+  margin: 0;
+}
+
+.teacher-admission-requests .modal-form-warning {
+  margin: 0;
+  font-size: 0.84rem;
+  color: #7a3a00;
+  background: #fff7eb;
+  border: 1px solid #f5dcb0;
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+
+.teacher-admission-requests .form-label {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--ink);
+  display: block;
+}
+
+.teacher-admission-requests .form-textarea {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #d7ccdf;
+  border-radius: 10px;
+  padding: 9px 12px;
+  font: inherit;
+  font-size: 0.88rem;
+  color: var(--ink);
+  background: #fff;
+  resize: vertical;
+  min-height: 80px;
+}
+
+.teacher-admission-requests .form-textarea:focus {
+  outline: 2px solid var(--teal);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.teacher-admission-requests .form-textarea--error {
+  border-color: #e05050;
+}
+
+.teacher-admission-requests .form-error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #8b2e39;
+  font-weight: 500;
+}
+
+.teacher-admission-requests .modal-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  .teacher-admission-requests .attendance-list-header {
+    grid-template-columns: 1fr auto;
+  }
+
+  .teacher-admission-requests .attendance-list-header .attendance-actions-col {
+    display: none;
+  }
+
+  .teacher-admission-requests .attendance-row {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+  }
+
+  .teacher-admission-requests .attendance-actions {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    min-width: 0;
+  }
+
+  .teacher-admission-requests .session-card-header {
+    flex-direction: column;
+  }
+}

--- a/src/pages/teacher/SessionConfirmationPage.jsx
+++ b/src/pages/teacher/SessionConfirmationPage.jsx
@@ -65,22 +65,30 @@ function isPresent(statusName) {
 
 function normalizeSessions(payload) {
   const items = Array.isArray(payload?.sessions) ? payload.sessions : []
-  return items.map((s) => ({
-    sessionId: Number(s.sessionId),
-    date: s.date || null,
-    startTime: s.startTime || null,
-    endTime: s.endTime || null,
-    studioName: String(s.studioName || '—').trim(),
-    modalityName: String(s.modalityName || '—').trim(),
-    status: String(s.status || '—').trim(),
-    students: Array.isArray(s.students) ? s.students.map((st) => ({
-      studentAccountId: Number(st.studentAccountId),
-      studentUserId: Number(st.studentUserId),
-      studentName: String(st.studentName || 'Aluno').trim(),
-      email: String(st.email || '').trim(),
-      attendanceStatus: String(st.attendanceStatus || '').trim(),
-    })) : [],
-  }))
+  return items.map((s) => {
+    const startDt = s.startTime ? new Date(s.startTime) : null
+    const endDt = s.endTime ? new Date(s.endTime) : null
+    const toHHMM = (dt) =>
+      dt && !isNaN(dt.getTime())
+        ? `${String(dt.getUTCHours()).padStart(2, '0')}:${String(dt.getUTCMinutes()).padStart(2, '0')}`
+        : null
+    return {
+      sessionId: Number(s.sessionId),
+      date: s.date || s.startTime || null,
+      startTime: toHHMM(startDt) || s.startTime || null,
+      endTime: toHHMM(endDt) || s.endTime || null,
+      studioName: String(s.studioName || '—').trim(),
+      modalityName: String(s.modalityName || '—').trim(),
+      status: String(s.status || s.statusName || '—').trim(),
+      students: Array.isArray(s.students) ? s.students.map((st) => ({
+        studentAccountId: Number(st.studentAccountId),
+        studentUserId: Number(st.studentUserId),
+        studentName: String(st.studentName || 'Aluno').trim(),
+        email: String(st.email || st.studentEmail || '').trim(),
+        attendanceStatus: String(st.attendanceStatus || '').trim(),
+      })) : [],
+    }
+  })
 }
 
 export default function SessionConfirmationPage() {
@@ -515,57 +523,55 @@ export default function SessionConfirmationPage() {
         open={noShowModal !== null}
         onClose={closeNoShowModal}
         title={`Registar falta sem aviso — ${noShowModal?.student?.studentName || 'Aluno'}`}
+        description="Esta ação regista a ausência sem aviso prévio e aplica a penalização financeira. Não pode ser desfeita."
+        footer={
+          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end' }}>
+            <Button variant="secondary" onClick={closeNoShowModal} disabled={noShowSubmitting}>
+              Cancelar
+            </Button>
+            <Button variant="danger" onClick={handleRegisterNoShow} disabled={noShowSubmitting}>
+              {noShowSubmitting ? 'A registar…' : 'Registar falta sem aviso'}
+            </Button>
+          </div>
+        }
       >
         {noShowModal && (
-          <div className="modal-form">
-            <div className="modal-form-info">
-              <p>
-                <strong>Sessão:</strong> #{noShowModal.session.sessionId} · {formatDate(noShowModal.session.date)} ·{' '}
-                {noShowModal.session.modalityName} · {noShowModal.session.studioName}
-              </p>
-              <p>
-                <strong>Aluno:</strong> {noShowModal.student.studentName}
-              </p>
-            </div>
-
-            <p className="modal-form-warning">
-              Esta ação regista a ausência do aluno sem aviso prévio e aplica uma penalização financeira conforme a regra BR-16. Esta ação não pode ser desfeita.
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <p>
+              <strong>Sessão:</strong> #{noShowModal.session.sessionId} · {formatDate(noShowModal.session.date)} · {noShowModal.session.modalityName} · {noShowModal.session.studioName}
+            </p>
+            <p>
+              <strong>Aluno:</strong> {noShowModal.student.studentName}
             </p>
 
-            <label className="form-label" htmlFor="no-show-remarks">
-              Observação <span aria-hidden="true">*</span>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <span>Observação <span aria-hidden="true">*</span></span>
+              <textarea
+                id="no-show-remarks"
+                rows={4}
+                value={noShowRemarks}
+                onChange={(e) => {
+                  setNoShowRemarks(e.target.value)
+                  if (noShowRemarksError) setNoShowRemarksError('')
+                }}
+                disabled={noShowSubmitting}
+                placeholder="Descreve a situação, tentativas de contacto, etc."
+                aria-describedby={noShowRemarksError ? 'no-show-remarks-error' : undefined}
+                style={{
+                  padding: '0.5rem',
+                  borderRadius: '8px',
+                  border: noShowRemarksError ? '1px solid #dc2626' : '1px solid var(--border)',
+                  font: 'inherit',
+                  resize: 'vertical',
+                }}
+              />
             </label>
-            <textarea
-              id="no-show-remarks"
-              className={['form-textarea', noShowRemarksError ? 'form-textarea--error' : ''].filter(Boolean).join(' ')}
-              rows={3}
-              placeholder="Descreve a situação, tentativas de contacto, etc."
-              value={noShowRemarks}
-              onChange={(e) => {
-                setNoShowRemarks(e.target.value)
-                if (noShowRemarksError) setNoShowRemarksError('')
-              }}
-              disabled={noShowSubmitting}
-              aria-describedby={noShowRemarksError ? 'no-show-remarks-error' : undefined}
-            />
+
             {noShowRemarksError && (
-              <p id="no-show-remarks-error" className="form-error" role="alert">
+              <p id="no-show-remarks-error" style={{ color: '#dc2626', margin: 0, fontSize: '0.875rem' }} role="alert">
                 {noShowRemarksError}
               </p>
             )}
-
-            <div className="modal-form-actions">
-              <Button variant="ghost" onClick={closeNoShowModal} disabled={noShowSubmitting}>
-                Cancelar
-              </Button>
-              <Button
-                variant="danger"
-                onClick={handleRegisterNoShow}
-                disabled={noShowSubmitting}
-              >
-                {noShowSubmitting ? 'A registar…' : 'Registar falta sem aviso'}
-              </Button>
-            </div>
           </div>
         )}
       </Modal>

--- a/src/pages/teacher/SessionConfirmationPage.jsx
+++ b/src/pages/teacher/SessionConfirmationPage.jsx
@@ -1,0 +1,584 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import api from '../../services/api'
+import { useAuth } from '../../hooks/useAuth'
+import notificationPreviewService from '../../services/notificationPreviewService'
+import Badge from '../../components/ui/Badge'
+import Button from '../../components/ui/Button'
+import LoadingSkeleton from '../../components/ui/LoadingSkeleton'
+import Modal from '../../components/ui/Modal'
+import Toast from '../../components/ui/Toast'
+import './AdmissionRequestsPage.css'
+import './SessionConfirmationPage.css'
+
+const NAV_ITEMS = [
+  { label: 'Painel', href: '/teacher/dashboard' },
+  { label: 'Pedidos de admissão', href: '/teacher/admission-requests' },
+  { label: 'Confirmação de sessões', href: '/teacher/sessions/confirmation' },
+]
+
+const NO_SHOW_STATUSES = new Set(['no_show', 'noshow', 'no-show'])
+const ATTENDANCE_CONFIRMED_STATUSES = new Set(['present', 'presente', 'confirmed', 'confirmado', 'attended'])
+
+function formatDate(value) {
+  if (!value) return '—'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return String(value)
+  return new Intl.DateTimeFormat('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric' }).format(parsed)
+}
+
+function formatTime(value) {
+  if (!value) return '—'
+  return String(value).slice(0, 5)
+}
+
+function formatNotificationDate(value) {
+  if (!value) return ''
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  const now = new Date()
+  const diffMs = now - parsed
+  const diffMins = Math.floor(diffMs / 60000)
+  if (diffMins < 1) return 'agora mesmo'
+  if (diffMins < 60) return `há ${diffMins} min`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `há ${diffHours}h`
+  return new Intl.DateTimeFormat('pt-PT', { dateStyle: 'short' }).format(parsed)
+}
+
+function resolveAttendanceBadge(statusName) {
+  const n = String(statusName || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+  if (NO_SHOW_STATUSES.has(n)) return { variant: 'danger', label: 'Falta s/ aviso' }
+  if (ATTENDANCE_CONFIRMED_STATUSES.has(n)) return { variant: 'ok', label: 'Presente' }
+  return { variant: 'neutral', label: 'Pendente' }
+}
+
+function isNoShow(statusName) {
+  const n = String(statusName || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+  return NO_SHOW_STATUSES.has(n)
+}
+
+function isPresent(statusName) {
+  const n = String(statusName || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+  return ATTENDANCE_CONFIRMED_STATUSES.has(n)
+}
+
+function normalizeSessions(payload) {
+  const items = Array.isArray(payload?.sessions) ? payload.sessions : []
+  return items.map((s) => ({
+    sessionId: Number(s.sessionId),
+    date: s.date || null,
+    startTime: s.startTime || null,
+    endTime: s.endTime || null,
+    studioName: String(s.studioName || '—').trim(),
+    modalityName: String(s.modalityName || '—').trim(),
+    status: String(s.status || '—').trim(),
+    students: Array.isArray(s.students) ? s.students.map((st) => ({
+      studentAccountId: Number(st.studentAccountId),
+      studentUserId: Number(st.studentUserId),
+      studentName: String(st.studentName || 'Aluno').trim(),
+      email: String(st.email || '').trim(),
+      attendanceStatus: String(st.attendanceStatus || '').trim(),
+    })) : [],
+  }))
+}
+
+export default function SessionConfirmationPage() {
+  const { logout, user } = useAuth()
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth <= 1024 : false
+  )
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sessions, setSessions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [toast, setToast] = useState(null)
+
+  const [noShowModal, setNoShowModal] = useState(null)
+  const [noShowRemarks, setNoShowRemarks] = useState('')
+  const [noShowRemarksError, setNoShowRemarksError] = useState('')
+  const [noShowSubmitting, setNoShowSubmitting] = useState(false)
+
+  const [confirmingSession, setConfirmingSession] = useState(null)
+
+  const [notificationsOpen, setNotificationsOpen] = useState(false)
+  const [notificationsLoaded, setNotificationsLoaded] = useState(false)
+  const [notificationsLoading, setNotificationsLoading] = useState(false)
+  const [notificationsError, setNotificationsError] = useState('')
+  const [notifications, setNotifications] = useState([])
+  const [notificationUnreadCount, setNotificationUnreadCount] = useState(0)
+
+  const notificationBoxRef = useRef(null)
+  const displayName = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || user?.email || 'Professor'
+
+  const sidebarHidden = isMobile || sidebarCollapsed
+  const appShellClassName = ['app-shell', sidebarHidden ? 'sidebar-hidden' : ''].filter(Boolean).join(' ')
+  const sidebarClassName = ['sidebar', isMobile && mobileOpen ? 'open' : ''].filter(Boolean).join(' ')
+
+  const handleSidebarToggle = useCallback(() => {
+    if (isMobile) {
+      setMobileOpen((v) => !v)
+      return
+    }
+    setSidebarCollapsed((v) => !v)
+  }, [isMobile])
+
+  const handleMobileNavClick = useCallback(() => {
+    if (isMobile) setMobileOpen(false)
+  }, [isMobile])
+
+  useEffect(() => {
+    const onResize = () => {
+      const mobile = window.innerWidth <= 1024
+      setIsMobile(mobile)
+      if (!mobile) setMobileOpen(false)
+    }
+    window.addEventListener('resize', onResize)
+    onResize()
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  const loadSessions = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const { data } = await api.get('/teacher/sessions/pending')
+      setSessions(normalizeSessions(data))
+    } catch {
+      setError('Não foi possível carregar as sessões. Tenta novamente.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadSessions()
+  }, [loadSessions])
+
+  useEffect(() => {
+    notificationPreviewService.getPreview({ limit: 0, includeUnreadCount: true })
+      .then((preview) => setNotificationUnreadCount(preview.unreadCount))
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!notificationsOpen) return
+    const onClick = (e) => {
+      if (notificationBoxRef.current && !notificationBoxRef.current.contains(e.target)) {
+        setNotificationsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [notificationsOpen])
+
+  const loadNotifications = useCallback(async () => {
+    if (notificationsLoaded || notificationsLoading) return
+    setNotificationsLoading(true)
+    setNotificationsError('')
+    try {
+      const preview = await notificationPreviewService.getPreview({ limit: 4, includeUnreadCount: true })
+      setNotifications(preview.items)
+      setNotificationsLoaded(true)
+      setNotificationUnreadCount(preview.unreadCount)
+    } catch {
+      setNotificationsError('Não foi possível carregar as notificações.')
+    } finally {
+      setNotificationsLoading(false)
+    }
+  }, [notificationsLoaded, notificationsLoading])
+
+  const handleNotificationsToggle = useCallback(() => {
+    setNotificationsOpen((v) => {
+      if (!v) loadNotifications()
+      return !v
+    })
+  }, [loadNotifications])
+
+  async function handleLogout() {
+    await logout()
+    navigate('/login', { replace: true })
+  }
+
+  async function handleConfirmSession(sessionId) {
+    setConfirmingSession(sessionId)
+    try {
+      await api.patch(`/teacher/sessions/${sessionId}/confirm-completion`)
+      setToast({ variant: 'success', title: 'Sessão confirmada', description: 'Conclusão da sessão confirmada. A gestão será notificada.' })
+      setSessions((prev) => prev.filter((s) => s.sessionId !== sessionId))
+    } catch (err) {
+      const msg = err?.response?.data?.error || 'Não foi possível confirmar a sessão.'
+      setToast({ variant: 'danger', title: 'Erro', description: msg })
+    } finally {
+      setConfirmingSession(null)
+    }
+  }
+
+  function openNoShowModal(session, student) {
+    setNoShowModal({ session, student })
+    setNoShowRemarks('')
+    setNoShowRemarksError('')
+  }
+
+  function closeNoShowModal() {
+    if (noShowSubmitting) return
+    setNoShowModal(null)
+    setNoShowRemarks('')
+    setNoShowRemarksError('')
+  }
+
+  async function handleRegisterNoShow() {
+    if (!noShowModal) return
+    const trimmedRemarks = noShowRemarks.trim()
+    if (!trimmedRemarks) {
+      setNoShowRemarksError('A observação é obrigatória para registar falta sem aviso.')
+      return
+    }
+    setNoShowSubmitting(true)
+    try {
+      await api.post(`/teacher/sessions/${noShowModal.session.sessionId}/no-show`, {
+        studentAccountId: noShowModal.student.studentAccountId,
+        remarks: trimmedRemarks,
+      })
+      setToast({
+        variant: 'success',
+        title: 'Falta registada',
+        description: `Falta sem aviso registada para ${noShowModal.student.studentName}. Penalização BR-16 aplicada.`,
+      })
+      setSessions((prev) =>
+        prev.map((s) => {
+          if (s.sessionId !== noShowModal.session.sessionId) return s
+          return {
+            ...s,
+            students: s.students.map((st) =>
+              st.studentAccountId === noShowModal.student.studentAccountId
+                ? { ...st, attendanceStatus: 'NO_SHOW' }
+                : st,
+            ),
+          }
+        }),
+      )
+      setNoShowModal(null)
+    } catch (err) {
+      const msg = err?.response?.data?.error || 'Não foi possível registar a falta. Tenta novamente.'
+      setNoShowRemarksError(msg)
+    } finally {
+      setNoShowSubmitting(false)
+    }
+  }
+
+  const sidebarToggleSymbol = isMobile
+    ? (mobileOpen ? '✕' : '☰')
+    : (sidebarCollapsed ? '▶' : '◀')
+
+  return (
+    <div className="teacher-admission-requests">
+    <div className={appShellClassName}>
+      {isMobile && mobileOpen ? (
+        <button
+          type="button"
+          className="sidebar-overlay"
+          aria-label="Fechar navegação lateral"
+          onClick={() => setMobileOpen(false)}
+        />
+      ) : null}
+      <aside className={sidebarClassName} id="sidebar">
+        <div className="brand">
+          <span className="brand-dot" aria-hidden="true" />
+          <div>
+            <h1>gestArtes</h1>
+            <p>Professor</p>
+          </div>
+        </div>
+
+        <div className="nav-group">
+          <h2>Professor</h2>
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              to={item.href}
+              className={['nav-link', location.pathname === item.href ? 'active' : ''].filter(Boolean).join(' ')}
+              onClick={handleMobileNavClick}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+
+        <div className="sidebar-footer">
+          <span className="sidebar-user">{displayName}</span>
+          <button type="button" className="nav-link logout-link" onClick={handleLogout}>
+            Terminar sessão
+          </button>
+        </div>
+      </aside>
+
+      <main className="main">
+        <header className="topbar">
+          <div className="topbar-left">
+            <button
+              type="button"
+              className="menu-toggle"
+              aria-label={isMobile ? (mobileOpen ? 'Fechar menu lateral' : 'Abrir menu lateral') : (sidebarCollapsed ? 'Mostrar barra lateral' : 'Esconder barra lateral')}
+              onClick={handleSidebarToggle}
+            >
+              {sidebarToggleSymbol}
+            </button>
+            <div>
+              <h2>Confirmação de sessões</h2>
+              <p>Valida a presença dos alunos e confirma a conclusão da sessão</p>
+            </div>
+          </div>
+          <div className="topbar-right" ref={notificationBoxRef} style={{ position: 'relative' }}>
+            <button
+              type="button"
+              className="pill"
+              aria-label="Notificações"
+              onClick={handleNotificationsToggle}
+            >
+              Notificações
+              {notificationUnreadCount > 0 && (
+                <span className="notif-badge" aria-live="polite">{notificationUnreadCount}</span>
+              )}
+            </button>
+
+            {notificationsOpen && (
+              <div className="notif-dropdown" role="dialog" aria-label="Painel de notificações">
+                <div className="notif-dropdown-header">
+                  <span>Notificações</span>
+                  <button type="button" className="icon-btn" onClick={() => setNotificationsOpen(false)} aria-label="Fechar notificações">✕</button>
+                </div>
+                <div className="notif-dropdown-body">
+                  {notificationsLoading && <p className="notif-empty">A carregar…</p>}
+                  {notificationsError && <p className="notif-empty notif-error">{notificationsError}</p>}
+                  {!notificationsLoading && !notificationsError && notifications.length === 0 && (
+                    <p className="notif-empty">Sem notificações.</p>
+                  )}
+                  {notifications.map((n) => (
+                    <div key={n.id} className={['notif-item', n.isRead ? '' : 'notif-item--unread'].filter(Boolean).join(' ')}>
+                      <p className="notif-title">{n.title}</p>
+                      {n.message && <p className="notif-message">{n.message}</p>}
+                      <p className="notif-date">{formatNotificationDate(n.createdAt)}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </header>
+
+        <div className="page-content">
+          {error && (
+            <div className="error-banner" role="alert">
+              <span>{error}</span>
+              <button type="button" onClick={loadSessions} className="retry-btn">
+                Tentar novamente
+              </button>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="sessions-grid">
+              {[1, 2].map((i) => (
+                <div key={i} className="panel">
+                  <LoadingSkeleton />
+                </div>
+              ))}
+            </div>
+          ) : sessions.length === 0 && !error ? (
+            <div className="panel empty-state">
+              <p className="empty-state-icon" aria-hidden="true">✓</p>
+              <h3>Sem sessões para confirmar</h3>
+              <p>Todas as sessões concluídas já foram confirmadas ou ainda não existem sessões terminadas.</p>
+            </div>
+          ) : (
+            <div className="sessions-grid">
+              {sessions.map((session) => {
+                const allHandled = session.students.every(
+                  (st) => isNoShow(st.attendanceStatus) || isPresent(st.attendanceStatus),
+                )
+                const isConfirming = confirmingSession === session.sessionId
+                const hasStudents = session.students.length > 0
+
+                return (
+                  <article key={session.sessionId} className="panel session-card">
+                    <div className="session-card-header">
+                      <div className="session-card-meta">
+                        <span className="session-ref">Sessão #{session.sessionId}</span>
+                        <span className="session-detail">{formatDate(session.date)}</span>
+                        <span className="session-detail">
+                          {formatTime(session.startTime)} – {formatTime(session.endTime)}
+                        </span>
+                        <span className="session-detail">{session.studioName}</span>
+                        <Badge variant="neutral">{session.modalityName}</Badge>
+                      </div>
+
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        disabled={isConfirming || !hasStudents}
+                        onClick={() => handleConfirmSession(session.sessionId)}
+                        title={
+                          !hasStudents
+                            ? 'Sem alunos inscritos'
+                            : allHandled
+                              ? 'Confirmar conclusão da sessão'
+                              : 'Confirmar conclusão (ainda há alunos por avaliar)'
+                        }
+                      >
+                        {isConfirming ? 'A confirmar…' : 'Confirmar conclusão'}
+                      </Button>
+                    </div>
+
+                    {!allHandled && hasStudents && (
+                      <p className="session-hint" role="status">
+                        {session.students.filter((st) => !isNoShow(st.attendanceStatus) && !isPresent(st.attendanceStatus)).length} aluno(s) por avaliar
+                      </p>
+                    )}
+
+                    <div className="attendance-list">
+                      <div className="attendance-list-header">
+                        <span>Aluno</span>
+                        <span>Estado</span>
+                        <span className="attendance-actions-col">Ações</span>
+                      </div>
+
+                      {!hasStudents && (
+                        <div className="attendance-row attendance-row--empty">
+                          <span>Sem alunos inscritos nesta sessão.</span>
+                        </div>
+                      )}
+
+                      {session.students.map((student) => {
+                        const attendanceBadge = resolveAttendanceBadge(student.attendanceStatus)
+                        const alreadyNoShow = isNoShow(student.attendanceStatus)
+                        const alreadyPresent = isPresent(student.attendanceStatus)
+                        const handled = alreadyNoShow || alreadyPresent
+
+                        return (
+                          <div
+                            key={student.studentAccountId}
+                            className={[
+                              'attendance-row',
+                              alreadyNoShow ? 'attendance-row--noshow' : '',
+                              alreadyPresent ? 'attendance-row--present' : '',
+                            ].filter(Boolean).join(' ')}
+                          >
+                            <div className="attendance-student">
+                              <span className="attendance-name">{student.studentName}</span>
+                              {student.email && (
+                                <span className="attendance-email">{student.email}</span>
+                              )}
+                            </div>
+
+                            <Badge variant={attendanceBadge.variant}>{attendanceBadge.label}</Badge>
+
+                            <div className="attendance-actions">
+                              {!handled && (
+                                <button
+                                  type="button"
+                                  className="attendance-btn attendance-btn--noshow"
+                                  onClick={() => openNoShowModal(session, student)}
+                                  aria-label={`Registar falta sem aviso para ${student.studentName}`}
+                                >
+                                  Falta s/ aviso
+                                </button>
+                              )}
+                              {alreadyNoShow && (
+                                <span className="attendance-action-done attendance-action-done--noshow">
+                                  Falta registada
+                                </span>
+                              )}
+                              {alreadyPresent && (
+                                <span className="attendance-action-done attendance-action-done--present">
+                                  Presença confirmada
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Modal
+        open={noShowModal !== null}
+        onClose={closeNoShowModal}
+        title={`Registar falta sem aviso — ${noShowModal?.student?.studentName || 'Aluno'}`}
+      >
+        {noShowModal && (
+          <div className="modal-form">
+            <div className="modal-form-info">
+              <p>
+                <strong>Sessão:</strong> #{noShowModal.session.sessionId} · {formatDate(noShowModal.session.date)} ·{' '}
+                {noShowModal.session.modalityName} · {noShowModal.session.studioName}
+              </p>
+              <p>
+                <strong>Aluno:</strong> {noShowModal.student.studentName}
+              </p>
+            </div>
+
+            <p className="modal-form-warning">
+              Esta ação regista a ausência do aluno sem aviso prévio e aplica uma penalização financeira conforme a regra BR-16. Esta ação não pode ser desfeita.
+            </p>
+
+            <label className="form-label" htmlFor="no-show-remarks">
+              Observação <span aria-hidden="true">*</span>
+            </label>
+            <textarea
+              id="no-show-remarks"
+              className={['form-textarea', noShowRemarksError ? 'form-textarea--error' : ''].filter(Boolean).join(' ')}
+              rows={3}
+              placeholder="Descreve a situação, tentativas de contacto, etc."
+              value={noShowRemarks}
+              onChange={(e) => {
+                setNoShowRemarks(e.target.value)
+                if (noShowRemarksError) setNoShowRemarksError('')
+              }}
+              disabled={noShowSubmitting}
+              aria-describedby={noShowRemarksError ? 'no-show-remarks-error' : undefined}
+            />
+            {noShowRemarksError && (
+              <p id="no-show-remarks-error" className="form-error" role="alert">
+                {noShowRemarksError}
+              </p>
+            )}
+
+            <div className="modal-form-actions">
+              <Button variant="ghost" onClick={closeNoShowModal} disabled={noShowSubmitting}>
+                Cancelar
+              </Button>
+              <Button
+                variant="danger"
+                onClick={handleRegisterNoShow}
+                disabled={noShowSubmitting}
+              >
+                {noShowSubmitting ? 'A registar…' : 'Registar falta sem aviso'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {toast && (
+        <Toast
+          variant={toast.variant}
+          title={toast.title}
+          description={toast.description}
+          onClose={() => setToast(null)}
+        />
+      )}
+    </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This pull request adds a new route for teachers to access the session confirmation page. The main changes are the import and registration of the new `SessionConfirmationPage` component in the teacher section of the app.

New teacher session confirmation page:

* Added import statement for `SessionConfirmationPage` in `src/App.jsx` to make the component available for routing.
* Registered the `/teacher/sessions/confirmation` route to render the `SessionConfirmationPage` component, enabling teachers to access the session confirmation feature.
<img width="1916" height="991" alt="imagem" src="https://github.com/user-attachments/assets/25439c0b-d71f-4fdb-aeeb-70b62fc7313f" />
Nota: não consegui fazer uma print com sessões de teste mas garanto que tinha ficado bem. 