### PR TITLE
feature: 7.3 implement loading and error handling #28

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { Toaster } from 'react-hot-toast'
 import { AuthProvider } from './context/AuthContext'
 import './index.css'
 import App from './App.jsx'
@@ -16,6 +17,7 @@ createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <AuthProvider>
+        <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
         <App />
       </AuthProvider>
     </BrowserRouter>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -6,6 +6,7 @@
  */
 
 import axios from 'axios'
+import toast from 'react-hot-toast'
 import { getApiBaseUrl } from '../utils/network'
 import {
   clearAccessToken,
@@ -15,6 +16,8 @@ import {
 
 let unauthorizedHandler = null
 let refreshPromise = null
+let lastGlobalErrorAt = 0
+const GLOBAL_ERROR_COOLDOWN = 4000
 
 export { clearAccessToken, getAccessToken, setAccessToken }
 
@@ -71,6 +74,7 @@ api.interceptors.response.use(
     const statusCode = error?.response?.status
     const requestUrl = String(error?.config?.url || '')
     const skipAuthHandler = Boolean(error?.config?.skipAuthHandler)
+    const isRequestCanceled = error?.code === 'ERR_CANCELED'
     const isRefreshRequest = requestUrl.includes('/auth/refresh')
     const isLoginRequest = requestUrl.includes('/auth/login')
     const alreadyRetried = Boolean(error?.config?._retry)
@@ -112,6 +116,17 @@ api.interceptors.response.use(
         statusCode,
         requestUrl,
       })
+    }
+
+    if (!isRequestCanceled) {
+      const isNetworkError = !error?.response
+      const isServerError = typeof statusCode === 'number' && statusCode >= 500
+      const canToast = Date.now() - lastGlobalErrorAt > GLOBAL_ERROR_COOLDOWN
+
+      if ((isNetworkError || isServerError) && canToast) {
+        lastGlobalErrorAt = Date.now()
+        toast.error('Erro inesperado. Tenta novamente.')
+      }
     }
 
     return Promise.reject(error)

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const createMock = vi.fn()
+const toastErrorMock = vi.fn()
+let responseErrorHandler = null
+
+vi.mock('axios', () => ({
+  default: {
+    create: createMock,
+  },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: toastErrorMock,
+  },
+}))
+
+vi.mock('../utils/network', () => ({
+  getApiBaseUrl: () => '/api',
+}))
+
+function setupAxiosMocks() {
+  responseErrorHandler = null
+
+  const apiInstance = {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: {
+        use: vi.fn((_success, error) => {
+          responseErrorHandler = error
+        }),
+      },
+    },
+  }
+
+  const refreshInstance = {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    post: vi.fn(),
+  }
+
+  createMock.mockImplementationOnce(() => apiInstance).mockImplementationOnce(() => refreshInstance)
+}
+
+async function loadApiModule() {
+  await import('./api')
+}
+
+describe('api interceptor global error toast', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    createMock.mockReset()
+    toastErrorMock.mockReset()
+  })
+
+  test('shows toast on network error', async () => {
+    setupAxiosMocks()
+    await loadApiModule()
+
+    await responseErrorHandler({ response: undefined, config: {} })
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Erro inesperado. Tenta novamente.')
+  })
+
+  test('shows toast on 5xx error', async () => {
+    setupAxiosMocks()
+    await loadApiModule()
+
+    await responseErrorHandler({ response: { status: 500 }, config: {} })
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Erro inesperado. Tenta novamente.')
+  })
+
+  test('does not show toast on 4xx error', async () => {
+    setupAxiosMocks()
+    await loadApiModule()
+
+    await responseErrorHandler({ response: { status: 404 }, config: {} })
+
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  test('does not show toast for canceled requests', async () => {
+    setupAxiosMocks()
+    await loadApiModule()
+
+    await responseErrorHandler({ code: 'ERR_CANCELED', response: undefined, config: {} })
+
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Summary
Added a global Axios response interceptor to show a generic error toast for network/5xx failures.
Mounted Toaster so toast notifications render reliably.
Added unit tests covering network errors, 5xx errors, non-5xx, and canceled requests.

Testing
npm run test
or
npx vitest run src/services/api.test.js

Notes
Scope intentionally limited to the global interceptor; no page-level refactors or auth flow changes.