### PR TITLE
implement new redirect automatically switch role

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -7,7 +7,7 @@
 
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import { hasRoleAccess, normalizeRoleList, toAppRole } from '../utils/roles'
+import { getDashboardPath, hasRoleAccess, normalizeRoleList, toAppRole } from '../utils/roles'
 
 export default function ProtectedRoute({ allowedRoles }) {
   const location = useLocation()
@@ -25,7 +25,7 @@ export default function ProtectedRoute({ allowedRoles }) {
   }
 
   if (normalizedAllowedRoles.length && !hasRoleAccess(currentRole, normalizedAllowedRoles)) {
-    return <Navigate to="/unauthorized" replace state={{ from, role: currentRole, allowedRoles: normalizedAllowedRoles }} />
+    return <Navigate to={getDashboardPath(currentRole)} replace state={{ from, role: currentRole, allowedRoles: normalizedAllowedRoles }} />
   }
 
   return <Outlet />

--- a/src/components/RoleSwitcher.jsx
+++ b/src/components/RoleSwitcher.jsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import { getDashboardPath, toAppRole } from '../utils/roles'
 
 const ROLE_LABELS = {
   student: 'Aluno',
@@ -15,18 +16,14 @@ const ROLE_LABELS = {
   admin: 'Direção',
 }
 
-const ROLE_HOME = {
-  student: '/student/dashboard',
-  teacher: '/teacher/dashboard',
-  admin: '/admin/dashboard',
-}
-
 export default function RoleSwitcher({ className }) {
   const { role, roles, switchRole } = useAuth()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [pendingRole, setPendingRole] = useState(null)
   const rootRef = useRef(null)
+  const currentRole = toAppRole(role)
 
   useEffect(() => {
     if (!open) return undefined
@@ -39,29 +36,32 @@ export default function RoleSwitcher({ className }) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [open])
 
-  const [pendingNav, setPendingNav] = useState(null)
-
   useEffect(() => {
-    if (pendingNav && role === pendingNav) {
-      navigate(ROLE_HOME[role] || '/')
-      setPendingNav(null)
+    if (!pendingRole || currentRole !== pendingRole) {
+      return
     }
-  }, [role, pendingNav, navigate])
+
+    navigate(getDashboardPath(currentRole), { replace: true })
+    setPendingRole(null)
+  }, [currentRole, navigate, pendingRole])
 
   const handleSwitch = useCallback(async (nextRole) => {
-    if (busy || nextRole === role) {
+    const normalizedNextRole = toAppRole(nextRole)
+
+    if (busy || normalizedNextRole === currentRole) {
       setOpen(false)
       return
     }
     setBusy(true)
     try {
-      await switchRole(nextRole)
+      const switchedRole = await switchRole(nextRole)
+      const normalizedSwitchedRole = toAppRole(switchedRole) || normalizedNextRole
       setOpen(false)
-      setPendingNav(nextRole)
+      setPendingRole(normalizedSwitchedRole)
     } finally {
       setBusy(false)
     }
-  }, [busy, role, switchRole])
+  }, [busy, currentRole, switchRole])
 
   if (!Array.isArray(roles) || roles.length < 2) {
     return null
@@ -89,7 +89,7 @@ export default function RoleSwitcher({ className }) {
         }}
       >
         <span aria-hidden="true" style={{ fontSize: '0.85rem' }}>👤</span>
-        <span>{ROLE_LABELS[role] || role}</span>
+        <span>{ROLE_LABELS[currentRole] || role}</span>
         <span aria-hidden="true" style={{ fontSize: '0.7rem', opacity: 0.6 }}>▾</span>
       </button>
 
@@ -112,7 +112,8 @@ export default function RoleSwitcher({ className }) {
           }}
         >
           {roles.map((r) => {
-            const isActive = r === role
+            const roleValue = toAppRole(r)
+            const isActive = roleValue === currentRole
             return (
               <li key={r}>
                 <button
@@ -138,7 +139,7 @@ export default function RoleSwitcher({ className }) {
                     gap: '8px',
                   }}
                 >
-                  <span>{ROLE_LABELS[r] || r}</span>
+                  <span>{ROLE_LABELS[roleValue] || r}</span>
                   {isActive ? <span aria-hidden="true" style={{ color: '#0b9d8f' }}>✓</span> : null}
                 </button>
               </li>


### PR DESCRIPTION
This pull request refactors how dashboard paths are determined and improves role normalization and navigation logic in both the `ProtectedRoute` and `RoleSwitcher` components. The main goal is to centralize dashboard path logic, ensure consistent role handling, and enhance navigation reliability when switching roles.

**Routing and Navigation Improvements:**

* Replaced hardcoded dashboard paths in both `ProtectedRoute` and `RoleSwitcher` with the new `getDashboardPath` utility function to centralize and standardize dashboard routing. [[1]](diffhunk://#diff-3cf225efdd3249cdbb4a00079ee96c37c812770558b71eb662ee96b5d2897958L10-R10) [[2]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aR11-R26) [[3]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aL42-R64)

**Role Normalization and Handling:**

* Updated all role comparisons and label lookups in `RoleSwitcher` to use the normalized role value from `toAppRole`, ensuring consistent behavior and display regardless of input format. [[1]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aR11-R26) [[2]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aL92-R92) [[3]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aL115-R116) [[4]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aL141-R142)

**Role Switch Navigation Logic:**

* Improved the navigation flow after switching roles: navigation now waits for the role change to complete and then redirects to the correct dashboard using the normalized role, preventing race conditions and navigation errors.

**Code Cleanup:**

* Removed the old `ROLE_HOME` mapping and related state variables, as dashboard routing is now handled by `getDashboardPath`. [[1]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aR11-R26) [[2]](diffhunk://#diff-cd96f2b77b85e6a1709c4f42bf5e73d1c8ca6b7141785a942a9e2dfd8f12922aL42-R64)